### PR TITLE
#179885 Add icmaa-meta module with inheritance logic for meta-tags

### DIFF
--- a/src/modules/icmaa-cms/mixins/categoryExtras.ts
+++ b/src/modules/icmaa-cms/mixins/categoryExtras.ts
@@ -1,10 +1,19 @@
 import { mapGetters } from 'vuex'
 import { CategoryExtrasStateItem } from '../types/CategoryExtrasState'
 
+import { htmlDecode } from '@vue-storefront/core/filters/html-decode'
+import { Logger } from '@vue-storefront/core/lib/logger';
+
 export default {
   async asyncData ({ store, route }) {
     const category = store.getters['category/getCurrentCategory']
     await store.dispatch('icmaaCmsCategoryExtras/single', { value: category.url_key })
+  },
+  methods: {
+    getCategoryExtrasValueOrCategoryValue (key: string, catKey: string = 'name'): any {
+      return this.categoryExtras && this.categoryExtras[key]
+        ? this.categoryExtras[key] : this.getCurrentCategory[catKey]
+    }
   },
   computed: {
     ...mapGetters('category', ['getCurrentCategory']),
@@ -13,7 +22,29 @@ export default {
       return this.categoryExtrasByCurrentCategory()
     },
     title (): string {
-      return this.categoryExtras ? this.categoryExtras.title : this.getCurrentCategory.name
+      return this.getCategoryExtrasValueOrCategoryValue('title')
+    },
+    description (): string {
+      return this.getCategoryExtrasValueOrCategoryValue('description')
+    },
+    metaTitle (): string {
+      return this.getCategoryExtrasValueOrCategoryValue('metaTitle')
+    },
+    metaDescription (): string|boolean {
+      return this.categoryExtras && this.categoryExtras.metaDescription
+        ? this.categoryExtras.metaDescription : false
+    }
+  },
+  metaInfo () {
+    let meta = []
+
+    if (this.metaDescription) {
+      meta.push({ vmid: 'description', name: 'description', content: htmlDecode(this.metaDescription) })
+    }
+
+    return {
+      title: htmlDecode(this.metaTitle),
+      meta
     }
   }
 }

--- a/src/modules/icmaa-cms/package.json
+++ b/src/modules/icmaa-cms/package.json
@@ -10,11 +10,11 @@
     "yaml": "^1.6.0"
   },
   "devDependencies": {
-    "@vue-storefront/module": "^0.0.8",
+    "@vue-storefront/module": "^0.0.9",
     "@vue-storefront/core": "^1.11.0-rc.1"
   },
   "peerDependencies": {
     "@vue-storefront/core": "^1.11.0-rc.1",
-    "@vue-storefront/module": "^0.0.8"
+    "@vue-storefront/module": "^0.0.9"
   }
 }

--- a/src/modules/icmaa-meta/README.md
+++ b/src/modules/icmaa-meta/README.md
@@ -1,0 +1,29 @@
+# `icmaa-meta` module
+
+Set store and logic for meta- and seo information.
+
+In `theme/resource/meta/` you need to add files like `head-uk.ts` to add a store-view specific meta file where you can extend the default meta infos of `theme/resource/meta/head.ts`. This data will be loaded on serverPrefetch into the root state and loaded in your layout.
+
+## Config
+
+1. Fetch state in default layout file of your theme (e.g. `Default.vue`) via `serverPrefetch()` like `this.$store.dispatch('icmaaMeta/load')`. Be sure to return a `promise` in `serverPrefetch()`, so if you fetch multiple actions it should look like:
+   ```javascript
+   return Promise.all([
+     this.fetchMetaData(), // Method which fetches the data via vuex store
+     this.otherData()
+   ])
+   ```
+2. Import meta info via getter like:
+   ```javascript
+   methods: {
+     ...mapGetters({ getMetaData: 'icmaaMeta/getData' })
+   },
+   metaInfo () {
+     return this.getMetaData()
+   }
+   ```
+
+## Todo
+
+[ ] Handle deep copy of Object[] to extend existing meta values etc. in `./helper/index.ts`
+[ ] Make config via `icmaa-cms` available

--- a/src/modules/icmaa-meta/README.md
+++ b/src/modules/icmaa-meta/README.md
@@ -1,8 +1,10 @@
 # `icmaa-meta` module
 
-Set store and logic for meta- and seo information.
+Set custom store and logic for meta- and seo information.
 
 In `theme/resource/meta/` you need to add files like `head-uk.ts` to add a store-view specific meta file where you can extend the default meta infos of `theme/resource/meta/head.ts`. This data will be loaded on serverPrefetch into the root state and loaded in your layout.
+
+VSF uses `vue-meta` as meta-tag handler, [read the docs](https://vue-meta.nuxtjs.org/) to learn more about it.
 
 ## Config
 
@@ -22,6 +24,39 @@ In `theme/resource/meta/` you need to add files like `head-uk.ts` to add a store
      return this.getMetaData()
    }
    ```
+
+## `head-*.ts` files
+
+Each file in `theme/resource/meta/` should return a JSON object following the `MetaInfo` interface of `vue-meta`.
+To extend a parent or default value you just need to overwrite it by it's key.
+
+If you like to update, add or remove nested array values like in "meta" or "script" use the following syntax:
+```javascript
+{
+  …
+  title: 'Overwrite default title',
+  add: [
+    {
+      type: 'meta',
+      data: { name: 'lorem-ipsum', content: 'Lorem ispum sit dolor.' }
+    }
+  ],
+  update: [
+    {
+      type: 'meta',
+      find: { name: 'description' },
+      data: { vmid: 'description', name: 'description', content: 'Other description' }
+    }
+  ],
+  remove: [
+    {
+      type: 'meta',
+      find: { charset: 'utf-8' }
+    }
+  ],
+  …
+}
+```
 
 ## Todo
 

--- a/src/modules/icmaa-meta/README.md
+++ b/src/modules/icmaa-meta/README.md
@@ -25,5 +25,4 @@ In `theme/resource/meta/` you need to add files like `head-uk.ts` to add a store
 
 ## Todo
 
-[ ] Handle deep copy of Object[] to extend existing meta values etc. in `./helper/index.ts`
 [ ] Make config via `icmaa-cms` available

--- a/src/modules/icmaa-meta/helper/ConfigMutator.ts
+++ b/src/modules/icmaa-meta/helper/ConfigMutator.ts
@@ -1,0 +1,77 @@
+import { MetaInfo } from 'vue-meta'
+
+export interface FindObject {
+  [prop: string]: any
+}
+
+export interface ExtendedMetaInfo extends MetaInfo {
+  add?: {
+    type: string,
+    data: any
+  }[],
+  update?: {
+    type: string,
+    find: FindObject,
+    data: any
+  }[],
+  remove?: {
+    type: string,
+    find: FindObject
+  }[]
+}
+
+export default class ConfigMutator {
+  public constructor (configs: any) {
+    this.configs = configs
+  }
+
+  public configs: any
+
+  public apply (changes: ExtendedMetaInfo): void {
+    if (!changes) {
+      return
+    }
+
+    if (changes.update) {
+      changes.update.forEach(e => this.update(e.type, e.find, e.data))
+    }
+
+    if (changes.add) {
+      changes.add.forEach(e => this.add(e.type, e.data))
+    }
+
+    if (changes.remove) {
+      changes.remove.forEach(e => this.remove(e.type, e.find))
+    }
+  }
+
+  public getRowIndex (type: string, find: FindObject): number|boolean {
+    const findKey = Object.keys(find)[0]
+    const findVal = find[findKey]
+    const findMet = e => e !== null && e.hasOwnProperty(findKey) && e[findKey] === findVal
+
+    if (this.configs[type].find(findMet)) {
+      return this.configs[type].findIndex(findMet)
+    }
+
+    return false
+  }
+
+  public add (type: string, value: any): void {
+    this.configs[type].push(value)
+  }
+
+  public remove (type: string, find: FindObject): void {
+    const index = this.getRowIndex(type, find)
+    if (typeof index === 'number') {
+      this.configs[type].splice(index, 1);
+    }
+  }
+
+  public update (type: string, find: FindObject, value: any): void {
+    const index = this.getRowIndex(type, find)
+    if (typeof index === 'number') {
+      this.configs[type][index] = value
+    }
+  }
+}

--- a/src/modules/icmaa-meta/helper/index.ts
+++ b/src/modules/icmaa-meta/helper/index.ts
@@ -2,13 +2,23 @@ import config from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import defaultsDeep from 'lodash-es/defaultsDeep'
 
+import ConfigMutator, { ExtendedMetaInfo } from './ConfigMutator'
+import { MetaInfo } from 'vue-meta'
+
 export const storeCode: Function = (): string => currentStoreView().storeCode || config.i18n.defaultLanguage.toLowerCase()
 export const storeLang: Function = (): string => currentStoreView().i18n.defaultLocale || config.i18n.defaultLocale
 
-export let mergeWithDefaults: any = (defaults: any, config: any) => {
+export let mergeWithDefaults: any = (defaults: MetaInfo, config: ExtendedMetaInfo) => {
+  const { add, update, remove } = config
+
+  delete config.add
+  delete config.update
+  delete config.remove
+
   defaultsDeep(defaults, config)
 
-  // @todo: Handle deep copy of Object[] to extend existing meta values etc.
+  const mutator = new ConfigMutator(defaults)
+  mutator.apply({ add, update, remove })
 
   return defaults
 }

--- a/src/modules/icmaa-meta/helper/index.ts
+++ b/src/modules/icmaa-meta/helper/index.ts
@@ -1,0 +1,14 @@
+import config from 'config'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import defaultsDeep from 'lodash-es/defaultsDeep'
+
+export const storeCode: Function = (): string => currentStoreView().storeCode || config.i18n.defaultLanguage.toLowerCase()
+export const storeLang: Function = (): string => currentStoreView().i18n.defaultLocale || config.i18n.defaultLocale
+
+export let mergeWithDefaults: any = (defaults: any, config: any) => {
+  defaultsDeep(defaults, config)
+
+  // @todo: Handle deep copy of Object[] to extend existing meta values etc.
+
+  return defaults
+}

--- a/src/modules/icmaa-meta/index.ts
+++ b/src/modules/icmaa-meta/index.ts
@@ -1,0 +1,6 @@
+import { StorefrontModule } from '@vue-storefront/module'
+import { IcmaaMetaStore } from './store'
+
+export const IcmaaMetaModule: StorefrontModule = function (app, store, router, moduleConfig, appConfig) {
+  store.registerModule('icmaaMeta', IcmaaMetaStore)
+}

--- a/src/modules/icmaa-meta/package.json
+++ b/src/modules/icmaa-meta/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "icmaa-meta",
+  "version": "1.0.0",
+  "author": "cewald <c.ewald@impericon.com> and contributors",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "@vue-storefront/module": "^0.0.9",
+    "@vue-storefront/core": "^1.11.0-rc.1"
+  },
+  "peerDependencies": {
+    "@vue-storefront/core": "^1.11.0-rc.1",
+    "@vue-storefront/module": "^0.0.9"
+  }
+}

--- a/src/modules/icmaa-meta/store/index.ts
+++ b/src/modules/icmaa-meta/store/index.ts
@@ -1,0 +1,45 @@
+import { Module } from 'vuex'
+import { Logger } from '@vue-storefront/core/lib/logger';
+
+import { storeCode } from '../helper'
+
+export default interface IcmaaMetaStoreState {
+  data?: {
+    title?: string,
+    titleTemplate?: string,
+    [propName: string]: any
+  }
+}
+
+export const IcmaaMetaStore: Module<IcmaaMetaStoreState, any> = {
+  namespaced: true,
+  state: { },
+  getters: {
+    getData: state => {
+      return state.data
+    }
+  },
+  actions: {
+    async load ({commit, rootState}, data) {
+      let metaData: any
+      try {
+        metaData = await import(/* webpackChunkName: "vsf-meta-[request]" */ `theme/resource/meta/head-${storeCode()}`)
+      } catch (err) {
+        try {
+          Logger.debug(`Unable to load meta infos for "${storeCode()}" so the default will be loaded.`, `icmaa-meta`, err)()
+          metaData = await import(/* webpackChunkName: "vsf-meta-default-[request]" */ `theme/resource/meta/head`)
+        } catch (err) {
+          Logger.error(`Unable to load meta infos:`, `icmaa-meta`, err)()
+          throw new Error('Unable to load meta infos')
+        }
+      }
+
+      commit('ICMAA_META_SET_DATA', metaData.default)
+    }
+  },
+  mutations: {
+    ICMAA_META_SET_DATA (state, data) {
+      state.data = data
+    }
+  }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -26,6 +26,7 @@ import { InstantCheckoutModule } from './instant-checkout'
 import { IcmaaExtendedUrlModule } from './icmaa-url'
 import { IcmaaCategoryModule } from './icmaa-category'
 import { IcmaaCmsModule } from './icmaa-cms'
+import { IcmaaMetaModule } from './icmaa-meta'
 
 import { registerModule } from '@vue-storefront/module'
 
@@ -58,6 +59,7 @@ export function registerNewModules () {
   registerModule(IcmaaExtendedUrlModule)
   registerModule(IcmaaCmsModule)
   registerModule(IcmaaCategoryModule)
+  registerModule(IcmaaMetaModule)
 }
 
 // Deprecated API, will be removed in 2.0

--- a/src/themes/icmaa-imp/assets/manifest.json
+++ b/src/themes/icmaa-imp/assets/manifest.json
@@ -1,6 +1,6 @@
 {
-    "short_name": "VSF Demo",
-    "name": "Vue Storefront",
+    "short_name": "Impericon",
+    "name": "Impericon - Live Your Music",
     "background_color": "#ffffff",
     "display": "standalone",
     "theme_color": "#ffffff",

--- a/src/themes/icmaa-imp/components/core/blocks/Header/MinimalHeader.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Header/MinimalHeader.vue
@@ -22,9 +22,7 @@
           <div class="col-xs-2 visible-xs" />
           <div class="col-sm-4 col-xs-4 center-xs">
             <div>
-              <a class="no-underline inline-flex" href="/" data-testid="logo">
-                <img width="auto" height="41px" src="/assets/logo.svg" alt="Vuestore logo">
-              </a>
+              <logo width="auto" height="41px" />
             </div>
           </div>
           <div class="col-xs-2 visible-xs" />
@@ -40,9 +38,13 @@
 
 <script>
 import CurrentPage from 'theme/mixins/currentPage'
+import Logo from 'theme/components/core/Logo'
 
 export default {
-  mixins: [CurrentPage]
+  mixins: [CurrentPage],
+  components: {
+    Logo
+  }
 }
 </script>
 

--- a/src/themes/icmaa-imp/head.ts
+++ b/src/themes/icmaa-imp/head.ts
@@ -12,7 +12,7 @@ export default {
   },
   meta: [
     { charset: 'utf-8' },
-    { vmid: 'description', name: 'description', content: 'Vue Dein offizieller Merchandise, Streetwear und Fanartikel Shop  - Impericon.com DE - Offizielles Merchandise, Streetwear, Fanartikel, Tickets und Schuhe im Impericon Shop - Innerhalb von 24 Stunden versandfertig - 30 Tage Rückgaberecht' },
+    { vmid: 'description', name: 'description', content: 'Dein offizieller Merchandise, Streetwear und Fanartikel Shop  - Impericon.com DE - Offizielles Merchandise, Streetwear, Fanartikel, Tickets und Schuhe im Impericon Shop - Innerhalb von 24 Stunden versandfertig - 30 Tage Rückgaberecht' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' },
     { name: 'robots', content: 'index, follow' },
     { name: 'mobile-web-app-capable', content: 'yes' },

--- a/src/themes/icmaa-imp/layouts/Default.vue
+++ b/src/themes/icmaa-imp/layouts/Default.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import AsyncSidebar from 'theme/components/theme/blocks/AsyncSidebar/AsyncSidebar.vue'
 import MainHeader from 'theme/components/core/blocks/Header/Header.vue'
 import MainFooter from 'theme/components/core/blocks/Footer/Footer.vue'
@@ -49,7 +49,6 @@ import SignUp from 'theme/components/core/blocks/Auth/SignUp.vue'
 import CookieNotification from 'theme/components/core/CookieNotification.vue'
 import OfflineBadge from 'theme/components/core/OfflineBadge.vue'
 import { isServer } from '@vue-storefront/core/helpers'
-import Head from 'theme/head'
 
 const SidebarMenu = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-sidebar-menu" */ 'theme/components/core/blocks/SidebarMenu/SidebarMenu.vue')
 const Microcart = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-microcart" */ 'theme/components/core/blocks/Microcart/Microcart.vue')
@@ -78,17 +77,24 @@ export default {
     })
   },
   methods: {
+    ...mapGetters({ getMetaData: 'icmaaMeta/getData' }),
     onOrderConfirmation (payload) {
       this.loadOrderConfirmation = true
       this.ordersData = payload
       this.$bus.$emit('modal-show', 'modal-order-confirmation')
+    },
+    fetchMetaData () {
+      return this.$store.dispatch('icmaaMeta/load')
     },
     fetchMenuData () {
       return this.$store.dispatch('icmaaCmsBlock/single', { value: 'navigation-main' })
     }
   },
   serverPrefetch () {
-    return this.fetchMenuData()
+    return Promise.all([
+      this.fetchMetaData(),
+      this.fetchMenuData()
+    ])
   },
   beforeMount () {
     // Progress bar on top of the page
@@ -105,7 +111,9 @@ export default {
   beforeDestroy () {
     this.$bus.$off('offline-order-confirmation', this.onOrderConfirmation)
   },
-  metaInfo: Head,
+  metaInfo () {
+    return this.getMetaData()
+  },
   components: {
     MainHeader,
     MainFooter,

--- a/src/themes/icmaa-imp/layouts/Minimal.vue
+++ b/src/themes/icmaa-imp/layouts/Minimal.vue
@@ -9,11 +9,9 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import MinimalHeader from 'theme/components/core/blocks/Header/MinimalHeader.vue'
 import MinimalFooter from 'theme/components/core/blocks/Footer/MinimalFooter.vue'
-
-import Head from 'theme/head'
 
 export default {
   data () {
@@ -27,12 +25,21 @@ export default {
     })
   },
   methods: {
+    ...mapGetters({ getMetaData: 'icmaaMeta/getData' }),
+    fetchMetaData () {
+      return this.$store.dispatch('icmaaMeta/load')
+    }
+  },
+  serverPrefetch () {
+    return this.fetchMetaData()
   },
   beforeMount () {
   },
   beforeDestroy () {
   },
-  metaInfo: Head,
+  metaInfo () {
+    return this.getMetaData()
+  },
   components: {
     MinimalHeader,
     MinimalFooter

--- a/src/themes/icmaa-imp/resource/meta/head-de.ts
+++ b/src/themes/icmaa-imp/resource/meta/head-de.ts
@@ -1,0 +1,9 @@
+import { mergeWithDefaults } from 'src/modules/icmaa-meta/helper'
+import defaults from './head'
+
+export default mergeWithDefaults(
+  defaults,
+  {
+    // Add store overwrites here …
+  }
+)

--- a/src/themes/icmaa-imp/resource/meta/head-de.ts
+++ b/src/themes/icmaa-imp/resource/meta/head-de.ts
@@ -5,26 +5,6 @@ export default mergeWithDefaults(
   defaults,
   {
     // Add vue-meta typed overwrites here …
-    //
-    // If you like to update nested array values like in "meta" or "script" use the following syntax:
-    // add: [
-    //   {
-    //     type: 'meta',
-    //     data: { name: 'lorem-ipsum', content: 'Lorem ispum sit dolor.' }
-    //   }
-    // ],
-    // update: [
-    //   {
-    //     type: 'meta',
-    //     find: { name: 'description' },
-    //     data: { vmid: 'description', name: 'description', content: 'Other description' }
-    //   }
-    // ],
-    // remove: [
-    //   {
-    //     type: 'meta',
-    //     find: { charset: 'utf-8' }
-    //   }
-    // ]
+    // See more information in src/modules/icmaa-meta/README.md
   }
 )

--- a/src/themes/icmaa-imp/resource/meta/head-de.ts
+++ b/src/themes/icmaa-imp/resource/meta/head-de.ts
@@ -4,6 +4,27 @@ import defaults from './head'
 export default mergeWithDefaults(
   defaults,
   {
-    // Add store overwrites here …
+    // Add vue-meta typed overwrites here …
+    //
+    // If you like to update nested array values like in "meta" or "script" use the following syntax:
+    // add: [
+    //   {
+    //     type: 'meta',
+    //     data: { name: 'lorem-ipsum', content: 'Lorem ispum sit dolor.' }
+    //   }
+    // ],
+    // update: [
+    //   {
+    //     type: 'meta',
+    //     find: { name: 'description' },
+    //     data: { vmid: 'description', name: 'description', content: 'Other description' }
+    //   }
+    // ],
+    // remove: [
+    //   {
+    //     type: 'meta',
+    //     find: { charset: 'utf-8' }
+    //   }
+    // ]
   }
 )

--- a/src/themes/icmaa-imp/resource/meta/head.ts
+++ b/src/themes/icmaa-imp/resource/meta/head.ts
@@ -1,12 +1,8 @@
-import config from 'config'
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { storeCode, storeLang } from 'src/modules/icmaa-meta/helper'
 
-const storeCode: string = currentStoreView().storeCode || config.i18n.defaultLanguage.toLowerCase()
-const storeLang: string = currentStoreView().i18n.defaultLocale || config.i18n.defaultLocale
-
-export default {
+const defaults: any = {
   title: 'Dein offizieller Merchandise, Streetwear und Fanartikel Shop',
-  titleTemplate: `%s - Impericon.com ${storeCode.toUpperCase()}`,
+  titleTemplate: `%s - Impericon.com ${storeCode().toUpperCase()}`,
   htmlAttrs: {
     lang: storeLang
   },
@@ -41,3 +37,5 @@ export default {
     }
   ]
 }
+
+export default defaults

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "paths": {
       "core/*": ["core/*"],
-      "theme/*": ["src/themes/default/*"], //needs testing with non-default theme!
+      "theme/*": ["src/themes/icmaa-imp/*", "src/themes/default/*"], //needs testing with non-default theme!
       "core/modules/*": ["./core/modules/*"],
       "@vue-storefront/*": ["./"]
     },


### PR DESCRIPTION
* Add new icmaa-meta module to:
  * Add custom store for meta-data
  * Load meta-data per store-view
  * Add meta-tag inheritance
* Improve default category meta-tags to use the category-extras ones
* Add our theme-path to `ts-config.json` for better IntelliJ