### PR TITLE
Bugfix for icmaa-cms/category-extras fetch on category-page

### DIFF
--- a/src/modules/icmaa-cms/store/category-extras/getters.ts
+++ b/src/modules/icmaa-cms/store/category-extras/getters.ts
@@ -7,7 +7,7 @@ const getters: GetterTree<CategoryExtrasState, RootState> = {
   categoryExtrasByIdentifier: (state) => (identifier): CategoryExtrasStateItem => {
     return state.items.find(item => item.identifier === identifier)
   },
-  categoryExtrasByCurrentCategory: (state, getters, rootState, rootGetters) => (): CategoryExtrasStateItem|boolean => {
+  categoryExtrasByCurrentCategory: (state, getters, rootState, rootGetters): CategoryExtrasStateItem|boolean => {
     const category = rootGetters['category-next/getCurrentCategory']
     if (category) {
       return getters.categoryExtrasByIdentifier(category.url_key)

--- a/src/themes/icmaa-imp/components/core/blocks/ICMAA/CategoryExtras/Header.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/ICMAA/CategoryExtras/Header.vue
@@ -11,7 +11,7 @@ export default {
   computed: {
     ...mapGetters('icmaaCmsCategoryExtras', ['categoryExtrasByCurrentCategory']),
     categoryExtras () {
-      return this.categoryExtrasByCurrentCategory()
+      return this.categoryExtrasByCurrentCategory
     }
   }
 }


### PR DESCRIPTION
* Prefetch category-extras data without VSF asyncData method to prevent bug with `routeStore.route`  in getters (https://github.com/DivanteLtd/vue-storefront/issues/3328)