### PR TITLE
#188009 Product-List-View progress and other improvements

### DIFF
--- a/src/modules/icmaa-catalog/README.md
+++ b/src/modules/icmaa-catalog/README.md
@@ -6,16 +6,57 @@ Add our custom functionality for the original `catalog` and `catalog-next` modul
 
 You can prefetch attribute option values and labels for specific attributes on several pages by adding them to `prefetchAttributes` value in configs. This way you can show option labels and values without the need to fetch them each time.
 ```
-  ...
-  "icmaa_catalog": {
-    "entities": {
-      "product": {
-        "prefetchAttributes": [
-          "band", "brand", ...
-        ]
-      }
+...
+"icmaa_catalog": {
+  "entities": {
+    "product": {
+      "prefetchAttributes": [
+        "band", "brand", ...
+      ]
     }
   }
+}
+```
+
+You can hide the X first category-path items in breadcrumbs using the following config value:
+```
+...
+"icmaa_catalog": {
+  "breadcrumbs": {
+    "skipRootCategories": 2,
+  },
+}
+```
+
+### Filters
+
+There are some new filter options to setup our filter logic. To find out what they are doing, look at the categore sidebar component in the theme.
+```
+...
+"systemFilterNames": ["sort", "pagesize"],
+  "defaultFilters": [
+    "price",
+    "size",
+    "type_top",
+    "type_shoes_height",
+    "type_top_sleeve",
+    ...
+  ],
+  "filterTree": {
+    "band": [], "brand": [],
+    "type_top": ["type_top_sleeve", "type_top_printtyp", "type_top_jackets", "type_top_cut", "type_jackets_lenght", "type_shirt_pattern"],
+    ...
+  },
+  "submenuFilters": ["band", "brand", ... ],
+  "singleOptionFilters": ["is_in_sale", "preorder"],
+  "filterTypeMapping": {
+    "color": ["color"],
+    "gender": ["gender"],
+    "price": ["price"],
+    "sale": ["is_in_sale"],
+    "list": ["type_top", "type_shoes_height", ... ],
+    "searchableList": ["band", "brand"]
+  },
 ```
 
 ## Todo

--- a/src/modules/icmaa-catalog/store/category/actions.ts
+++ b/src/modules/icmaa-catalog/store/category/actions.ts
@@ -6,8 +6,6 @@ import { router } from '@vue-storefront/core/app'
 import { products } from 'config'
 import { changeFilterQuery } from '@vue-storefront/core/modules/catalog-next/helpers/filterHelpers'
 
-import { Logger } from '@vue-storefront/core/lib/logger'
-
 const actions: ActionTree<CategoryState, RootState> = {
   async unsetSearchFilterForAttribute ({ dispatch, getters }, attributeKey: string) {
     let currentQuery = router.currentRoute[products.routerFiltersSource]

--- a/src/modules/icmaa-catalog/store/category/getters.ts
+++ b/src/modules/icmaa-catalog/store/category/getters.ts
@@ -2,9 +2,30 @@ import config from 'config'
 import { GetterTree } from 'vuex'
 import RootState from '@vue-storefront/core/types/RootState'
 import CategoryState from '@vue-storefront/core/modules/catalog-next/store/category/CategoryState'
+import { parseCategoryPath } from '@vue-storefront/core/modules/breadcrumbs/helpers'
+import { _prepareCategoryPathIds } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers';
 import intersection from 'lodash-es/intersection'
 
+import { Logger } from '@vue-storefront/core/lib/logger'
+
 const getters: GetterTree<CategoryState, RootState> = {
+  getBreadcrumbsFor: (state, getters) => category => {
+    if (!category) {
+      return []
+    }
+
+    let categoryHierarchyIds = _prepareCategoryPathIds(category)
+    const skipRootCategories = config.icmaa_catalog.breadcrumbs.skipRootCategories
+    if (skipRootCategories && skipRootCategories > 0) {
+      categoryHierarchyIds.splice(0, skipRootCategories)
+    }
+
+    const resultCategoryList = categoryHierarchyIds
+      .map(categoryId => getters.getCategoriesMap[categoryId])
+      .filter(c => !!c)
+
+    return parseCategoryPath(resultCategoryList)
+  },
   isActiveFilterAttribute: (state, getters) => (attributeKey: string) => {
     return (getters.getCurrentFilters[attributeKey])
   },

--- a/src/modules/icmaa-cms/helpers/genericStateModule.ts
+++ b/src/modules/icmaa-cms/helpers/genericStateModule.ts
@@ -1,0 +1,39 @@
+import { StorefrontModule } from '@vue-storefront/core/lib/modules'
+import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
+import { registerModule } from '@vue-storefront/core/lib/modules'
+import createGenericStore from '../store/generic'
+
+import { Module } from 'vuex'
+import RootState from '@vue-storefront/core/types/RootState'
+import GenericState from '../types/GenericState'
+
+import { Logger } from '@vue-storefront/core/lib/logger'
+import camelCase from 'lodash-es/camelCase'
+
+let registeredGenericCmsStateModules: string[] = []
+
+const registerGenericCmsStateModule = (stateKey: string, documentType: string, extendStore: Module<GenericState, RootState>) => {
+  const namespace = 'icmaa-cms-' + stateKey
+  const ccNamespace = camelCase(namespace)
+
+  if (registeredGenericCmsStateModules.includes(ccNamespace)) {
+    Logger.debug('Generic cms state module is already loaded:', 'icmaa-cms', ccNamespace)()
+    return
+  }
+
+  const Module: StorefrontModule = function ({ store }) {
+    StorageManager.init(namespace)
+    store.registerModule(ccNamespace, createGenericStore(stateKey, namespace, documentType, extendStore))
+
+    Logger.debug('Loaded generic cms state module:', 'icmaa-cms', ccNamespace)()
+  }
+
+  try {
+    registerModule(Module)
+    registeredGenericCmsStateModules.push(ccNamespace)
+  } catch (exception) {
+    Logger.error('Failed to load generic cms state module:', 'icmaa-cms', ccNamespace)()
+  }
+}
+
+export default registerGenericCmsStateModule

--- a/src/modules/icmaa-cms/store/generic/actions.ts
+++ b/src/modules/icmaa-cms/store/generic/actions.ts
@@ -1,0 +1,25 @@
+import { ActionTree } from 'vuex'
+import { single as singleAbstract, list as listAbstract, MutationTypesInterface, SingleOptionsInterface, ListOptionsInterface } from '../abstract/actions'
+
+import getTypes from './mutation-types'
+import GenericState, { GenericStateItem } from '../../types/GenericState'
+import RootState from '@vue-storefront/core/types/RootState'
+
+const actions = (stateKey: string, storageKey: string, documentType: string): ActionTree<GenericState, RootState> => {
+  const types = getTypes(stateKey)
+  const mutationPrefix = stateKey.toUpperCase()
+  const mutationTypes: MutationTypesInterface = {
+    add: types[`${mutationPrefix}_ADD`],
+    upd: types[`${mutationPrefix}_UPD`],
+    rmv: types[`${mutationPrefix}_RMV`]
+  }
+
+  return {
+    single: async (context, options: SingleOptionsInterface): Promise<GenericStateItem> =>
+      singleAbstract<GenericStateItem>({ documentType, mutationTypes, storageKey, context, options, identifier: 'uuid' }),
+    list: async (context, options: Record<string, any> = {}): Promise<GenericStateItem[]> =>
+      listAbstract<GenericStateItem>({ documentType, mutationTypes, storageKey, context, options, identifier: 'uuid' })
+  }
+}
+
+export default actions

--- a/src/modules/icmaa-cms/store/generic/getters.ts
+++ b/src/modules/icmaa-cms/store/generic/getters.ts
@@ -1,0 +1,11 @@
+import { GetterTree } from 'vuex'
+import GenericState, { GenericStateItem } from '../../types/GenericState'
+import RootState from '@vue-storefront/core/types/RootState'
+
+const getters = (stateKey: string): GetterTree<GenericState, RootState> => {
+  return {
+    getAll: (state): GenericStateItem[] => state.items
+  }
+}
+
+export default getters

--- a/src/modules/icmaa-cms/store/generic/index.ts
+++ b/src/modules/icmaa-cms/store/generic/index.ts
@@ -1,0 +1,28 @@
+import { Module } from 'vuex'
+import actions from './actions'
+import getters from './getters'
+import mutations from './mutations'
+import RootState from '@vue-storefront/core/types/RootState'
+import GenericState from '../../types/GenericState'
+
+import merge from 'lodash-es/merge'
+
+const createGenericStore = (stateKey: string, storageKey: string, documentType: string, ExtendStore: Module<GenericState, RootState>): Module<GenericState, RootState> => {
+  let GenericStore: Module<GenericState, RootState> = {
+    namespaced: true,
+    state: {
+      items: []
+    },
+    getters: getters(stateKey),
+    actions: actions(stateKey, storageKey, documentType),
+    mutations: mutations(stateKey)
+  }
+
+  if (ExtendStore) {
+    GenericStore = merge(GenericStore, ExtendStore)
+  }
+
+  return GenericStore
+}
+
+export default createGenericStore

--- a/src/modules/icmaa-cms/store/generic/mutation-types.ts
+++ b/src/modules/icmaa-cms/store/generic/mutation-types.ts
@@ -1,0 +1,10 @@
+import { SN_ICMAA_CMS } from '../abstract/mutation-types'
+
+export default (stateKey: string) => {
+  stateKey = stateKey.toUpperCase()
+  return {
+    [`${stateKey}_ADD`]: `${SN_ICMAA_CMS}/ADD_${stateKey}`,
+    [`${stateKey}_UPD`]: `${SN_ICMAA_CMS}/UPDATE_${stateKey}`,
+    [`${stateKey}_RMV`]: `${SN_ICMAA_CMS}/REMOVE_${stateKey}`
+  }
+}

--- a/src/modules/icmaa-cms/store/generic/mutations.ts
+++ b/src/modules/icmaa-cms/store/generic/mutations.ts
@@ -1,0 +1,17 @@
+import { MutationTree } from 'vuex'
+import { mutationsFactory } from '../abstract/mutations'
+import getTypes from './mutation-types'
+import GenericState from '../../types/GenericState'
+
+const mutations = (stateKey: string): MutationTree<GenericState> => {
+  const types = getTypes(stateKey)
+  stateKey = stateKey.toUpperCase()
+
+  return mutationsFactory({
+    add: types[`${stateKey}_ADD`],
+    upd: types[`${stateKey}_UPD`],
+    rmv: types[`${stateKey}_RMV`]
+  }, 'uuid')
+}
+
+export default mutations

--- a/src/modules/icmaa-cms/types/GenericState.ts
+++ b/src/modules/icmaa-cms/types/GenericState.ts
@@ -1,0 +1,9 @@
+import { AbstractStateItem } from 'icmaa-cms/types/AbstractState'
+
+export interface GenericStateItem extends AbstractStateItem {
+  [key: string]: any
+}
+
+export default interface GenericState {
+  items: GenericStateItem[]
+}

--- a/src/themes/icmaa-imp/components/core/Breadcrumbs.vue
+++ b/src/themes/icmaa-imp/components/core/Breadcrumbs.vue
@@ -1,20 +1,34 @@
 <template>
-  <div class="t-text-sm t-text-base-tone">
+  <div class="t-flex t-items-center t-text-sm t-text-base-tone">
     <template v-for="(link, index) in paths">
-      <router-link :to="link.route_link" :key="index">
-        {{ link.name | htmlDecode }}
+      <router-link :to="link.route_link" :key="index" class="t-text-base-tone hover:t-text-base-dark">
+        <template v-if="index === 0">
+          <material-icon icon="home" size="xs" class="t-align-middle" />
+          <span class="t-sr-only">{{ link.name | htmlDecode }}</span>
+        </template>
+        <template v-else>
+          {{ link.name | htmlDecode }}
+        </template>
       </router-link>
-      <span class="t-mx-2" :key="'bullet-' + index" v-text="spacerCharacter" />
+      <span class="t-mx-3 lg:t-mx-4 t-text-xs t-font-thin" :key="'bullet-' + index" v-text="spacerCharacter" />
     </template>
-    <span class="t-text-base-darkest" v-text="current || htmlDecode" />
+    <span class="t-text-base-tone" v-text="current || htmlDecode" />
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
 import i18n from '@vue-storefront/i18n'
+import last from 'lodash-es/last'
+
+import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
 
 export default {
+  name: 'Breadcrumbs',
+  components: {
+    MaterialIcon
+  },
   props: {
     spacerCharacter: {
       type: String,
@@ -27,7 +41,7 @@ export default {
     },
     withHomepage: {
       type: Boolean,
-      default: false
+      default: true
     },
     activeRoute: {
       type: String,
@@ -35,8 +49,11 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      breadcrumbs: 'category-next/getBreadcrumbs'
+    }),
     paths () {
-      const routes = this.routes ? this.routes : this.$store.state.breadcrumbs.routes
+      let routes = (this.routes ? this.routes : this.breadcrumbs).filter(r => r.name !== this.current)
 
       if (this.withHomepage) {
         return [
@@ -48,7 +65,7 @@ export default {
       return routes
     },
     current () {
-      return this.activeRoute || this.$store.state.breadcrumbs.current
+      return this.activeRoute || last(this.breadcrumbs.name)
     }
   }
 }

--- a/src/themes/icmaa-imp/components/core/blocks/Advice/Advice.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Advice/Advice.vue
@@ -45,25 +45,26 @@ export default {
       this.$router.push(this.localizedRoute(this.advice.link))
     }
   },
-  created () {
-    this.$store.dispatch('claims/check', { claimCode: 'adviceClaimAccepted' })
-      .then(claim => {
-        if (!claim) {
-          this.isOpen = true
-          this.$store.dispatch('claims/set', { claimCode: 'adviceClaimAccepted', value: false })
-        } else {
-          this.isOpen = !claim.value
-        }
-      })
-  },
   computed: {
     ...mapGetters('icmaaAdvice', ['getSingleAdvice']),
     advice () {
       return this.getSingleAdvice(this.tags)
     }
   },
-  mounted () {
-    this.$store.dispatch('icmaaAdvice/list', this.tags)
+  async mounted () {
+    await this.$store.dispatch('claims/check', { claimCode: 'adviceClaimAccepted' })
+      .then(async claim => {
+        if (!claim) {
+          this.isOpen = true
+          await this.$store.dispatch('claims/set', { claimCode: 'adviceClaimAccepted', value: false })
+        } else {
+          this.isOpen = !claim.value
+        }
+      })
+
+    if (this.isOpen) {
+      this.$store.dispatch('icmaaAdvice/list', this.tags)
+    }
   }
 }
 </script>

--- a/src/themes/icmaa-imp/components/core/blocks/Category/Presets.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/Presets.vue
@@ -16,6 +16,7 @@ import mapValues from 'lodash-es/mapValues'
 import intersection from 'lodash-es/intersection'
 import pick from 'lodash-es/pick'
 import sampleSize from 'lodash-es/sampleSize'
+import orderBy from 'lodash-es/orderBy'
 
 export default {
   beforeCreate () {
@@ -86,9 +87,9 @@ export default {
       presets = sampleSize(presets, this.limit)
 
       if (cluster) {
-        const presetsWithCluster = presets.filter(p => p.clusters)
-        const presetsWithoutCluster = presets.filter(p => !p.clusters)
-        presets = presetsWithCluster.concat(presetsWithoutCluster)
+        presets = orderBy(presets, ['active', 'cluster'], ['desc', 'asc'])
+      } else {
+        presets = orderBy(presets, ['active'], ['desc'])
       }
 
       return presets

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLine.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLine.vue
@@ -75,6 +75,13 @@ export default {
     logoClassObj () {
       return typeof this.logoClass === 'string' ? [this.logoClass] : this.logoClass
     }
+  },
+  watch: {
+    logoLineItems (items) {
+      if (items.length > 0) {
+        this.$emit('loaded')
+      }
+    }
   }
 }
 </script>

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLineBlock.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLineBlock.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="t-w-full lg:t-w-1/2 t-px-4">
+  <div class="t-w-full lg:t-w-1/2 t-px-4" v-show="!loading">
     <h4 class="t-flex t-justify-between t-items-center t-text-xl t-text-base-dark t-mb-4">
       {{ $t('Our {department}', { department: $t(title) }) }}
       <router-link :to="localizedRoute(path)" class="t-inline-block t-l t-text-primary t-text-xs t-leading-loose">
         {{ $t('View all {department}', { department: $t(title) }) }}
       </router-link>
     </h4>
-    <logo-line :parent-id="parentId" :limit="10" logo-class="t-mb-4" class="t-justify-between t--mx-2" />
+    <logo-line :parent-id="parentId" :limit="10" logo-class="t-mb-4" class="t-justify-between t--mx-2" @loaded="loading = false" />
   </div>
 </template>
 
@@ -16,6 +16,11 @@ import LogoLine from 'theme/components/core/blocks/CategoryExtras/LogoLine'
 export default {
   components: {
     LogoLine
+  },
+  data () {
+    return {
+      loading: true
+    }
   },
   props: {
     parentId: {

--- a/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -1,10 +1,10 @@
 <template>
-  <sidebar>
+  <sidebar class="t-min-h-screen">
     <template v-slot:top>
       <top-button icon="person" :text="loginButtonText" :tab-index="2" class="t-text-base-light" @click.native="login" />
     </template>
     <template v-slot:default>
-      <div class="t-flex t-flex-wrap t--mx-1">
+      <div class="t-flex t-flex-wrap t--mx-1 t--mb-2">
         <navigation-item v-for="link in getMainNavigation" v-bind="link" :key="link.id" />
       </div>
     </template>

--- a/src/themes/icmaa-imp/layouts/Default.vue
+++ b/src/themes/icmaa-imp/layouts/Default.vue
@@ -4,7 +4,9 @@
     <loader />
     <div id="viewport" class="w-100 relative">
       <main-header />
-      <advice tags="2" />
+      <no-ssr>
+        <advice tags="2" />
+      </no-ssr>
       <async-sidebar
         :async-component="SearchPanel"
         :is-open="isSearchPanelOpen"
@@ -54,6 +56,7 @@ import CookieNotification from 'theme/components/core/CookieNotification.vue'
 import OfflineBadge from 'theme/components/core/OfflineBadge.vue'
 import { isServer } from '@vue-storefront/core/helpers'
 import viewportMixin from 'theme/mixins/viewportMixin.ts'
+import NoSSR from 'vue-no-ssr'
 
 const SidebarMenu = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-sidebar-menu" */ 'theme/components/core/blocks/SidebarMenu/SidebarMenu.vue')
 const Microcart = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-microcart" */ 'theme/components/core/blocks/Microcart/Microcart.vue')
@@ -136,7 +139,8 @@ export default {
     CookieNotification,
     OfflineBadge,
     OrderConfirmation,
-    AsyncSidebar
+    AsyncSidebar,
+    'no-ssr': NoSSR
   }
 }
 </script>

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -2,7 +2,7 @@
   <div id="category">
     <header class="t-container">
       <div class="t-flex t-flex-wrap t-px-4 t-mb-8">
-        <breadcrumbs :routes="getBreadcrumbs" :active-route="getCurrentCategory.name" class="t-w-full t-my-8" />
+        <breadcrumbs :routes="breadcrumbs" :active-route="getCurrentCategory.name" class="t-w-full t-my-8" />
         <category-extras-header />
         <div class="t-w-full">
           <div class="t-flex t-flex-wrap t-items-center t--mx-1 lg:t--mx-2">
@@ -136,6 +136,7 @@ export default {
       isSidebarOpen: state => state.ui.categoryfilter
     }),
     ...mapGetters({
+      breadcrumbs: 'category-next/getBreadcrumbs',
       getCurrentSearchQuery: 'category-next/getCurrentSearchQuery',
       getCategoryProducts: 'category-next/getCategoryProducts',
       getCurrentCategory: 'category-next/getCurrentCategory',
@@ -147,9 +148,6 @@ export default {
     },
     isCategoryEmpty () {
       return this.getCategoryProductsTotal === 0
-    },
-    getBreadcrumbs () {
-      return this.$store.getters['category-next/getBreadcrumbs'].filter(breadcrumb => breadcrumb.name !== this.getCurrentCategory.name)
     },
     pageSizeOptions () {
       return this.pageSizes.map(s => { return { value: s, label: s } })

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -2,7 +2,7 @@
   <div id="product" itemscope itemtype="http://schema.org/Product">
     <div class="t-container t-px-4">
       <div class="t--mx-4 lg:t-px-4 t-flex t-flex-wrap">
-        <breadcrumbs class="breadcrumbs t-w-full t-my-8 t-hidden lg:t-block" :routes="breadcrumbs" :active-route="product.name" />
+        <breadcrumbs class="breadcrumbs t-w-full t-my-8 t-hidden lg:t-flex" :routes="breadcrumbs" :active-route="product.name" />
         <category-extras-header class="t-bg-white t-border-b t-border-base-lightest" v-if="viewport === 'sm'" />
         <product-gallery
           class="product-gallery t-w-full t-border-base-lightest t-border-b t-bg-white lg:t-w-1/2 lg:t-border-b-0"

--- a/src/themes/icmaa-imp/tailwind.js
+++ b/src/themes/icmaa-imp/tailwind.js
@@ -53,6 +53,7 @@ module.exports = {
         '2-1/2xl': '1.625rem'
       },
       lineHeight: {
+        '1-em': '1em',
         '1-rem': '1rem',
         'looser': '3',
         'super-loose': '4'


### PR DESCRIPTION
* Add breadcrumbs logic (hide root-category and better styling)
* Add bugix for spacing-bug in PDP breadcrumbs
* Category-Filter-Preset:
  * Only show available presets and sort them
  * Cluster presets
  * Load presets from storyblok
* Add generic cms state module registration:
  * Create a way to dynamically load stuff to state-management without adding a whole new module each time
  * E.g.: Filter-Presets, we only need them on the PLP and don't want to write a module to only get the list content from the CMS
* Only show logo-line-block if items exist
* Load advice only if client and cookie not set