### PR TITLE
Extend ElasticSearch-Adapter to allow `or` and `or-null` filters

### DIFF
--- a/src/modules/icmaa-category/store/actions.ts
+++ b/src/modules/icmaa-category/store/actions.ts
@@ -37,8 +37,8 @@ const actions: ActionTree<CategoryState, RootState> = {
       return { parent, list: list as Category[] }
     }
   },
-  async loadProductListingWidgetProducts ({ state, commit, dispatch }, params: { categoryId: number, cluster: string, size: number, sort: string }): Promise<ProductListingWidgetState> {
-    const { categoryId, cluster, size, sort } = params
+  async loadProductListingWidgetProducts ({ state, commit, dispatch }, params: { categoryId: number, cluster: string, size: number, sort: string|string[] }): Promise<ProductListingWidgetState> {
+    let { categoryId, cluster, size, sort } = params
 
     if (state.productListingWidget.find(i => i.parent === categoryId && i.list.length >= size)) {
       return
@@ -51,7 +51,9 @@ const actions: ActionTree<CategoryState, RootState> = {
       .applyFilter({ key: 'category_ids', value: { in: [categoryId] } })
 
     if (cluster) {
-      query.applyFilter({ key: 'customercluster', value: { in: [parseInt(cluster)] } })
+      query.applyFilter({ key: 'customercluster', value: { or: [parseInt(cluster)] } })
+      query.applyFilter({ key: 'customercluster', value: { or: null } })
+      sort = [sort as string, 'customercluster:desc']
     }
 
     return dispatch('product/findProducts', { query, size, sort }, { root: true }).then(products => {

--- a/src/search/adapter/api/searchAdapter.ts
+++ b/src/search/adapter/api/searchAdapter.ts
@@ -1,0 +1,85 @@
+import { SearchAdapter as OrgSearchAdapter } from '@vue-storefront/core/lib/search/adapter/api/searchAdapter'
+import { prepareElasticsearchQueryBody } from './elasticsearchQuery'
+
+import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
+import HttpQuery from '@vue-storefront/core/types/search/HttpQuery'
+import { processURLAddress } from '@vue-storefront/core/helpers'
+import { currentStoreView, prepareStoreView } from '@vue-storefront/core/lib/multistore'
+import config from 'config'
+import queryString from 'query-string'
+
+export class SearchAdapter extends OrgSearchAdapter {
+  /**
+   * Duplicate of @vue-storefront/core/lib/search/adapter/api/searchAdapter.ts
+   * to include our extended `prepareElasticsearchQueryBody` method changes
+   * @param Request
+   */
+  public async search (Request) {
+    if (!this.entities[Request.type]) {
+      throw new Error('No entity type registered for ' + Request.type)
+    }
+    let ElasticsearchQueryBody = {}
+    if (Request.searchQuery instanceof SearchQuery) {
+      ElasticsearchQueryBody = await prepareElasticsearchQueryBody(Request.searchQuery)
+      if (Request.searchQuery.getSearchText() !== '') {
+        ElasticsearchQueryBody['min_score'] = config.elasticsearch.min_score
+      }
+    } else {
+      // backward compatibility for old themes uses bodybuilder
+      ElasticsearchQueryBody = Request.searchQuery
+    }
+    if (Request.hasOwnProperty('groupId') && Request.groupId !== null) {
+      ElasticsearchQueryBody['groupId'] = Request.groupId
+    }
+    if (Request.hasOwnProperty('groupToken') && Request.groupToken !== null) {
+      ElasticsearchQueryBody['groupToken'] = Request.groupToken
+    }
+
+    const storeView = (Request.store === null) ? currentStoreView() : await prepareStoreView(Request.store)
+
+    Request.index = storeView.elasticsearch.index
+
+    let url = processURLAddress(storeView.elasticsearch.host)
+
+    if (this.entities[Request.type].url) {
+      url = this.entities[Request.type].url
+    }
+
+    const httpQuery: HttpQuery = {
+      size: Request.size,
+      from: Request.from,
+      sort: Request.sort
+    }
+
+    if (Request._sourceExclude) {
+      httpQuery._source_exclude = Request._sourceExclude.join(',')
+    }
+    if (Request._sourceInclude) {
+      httpQuery._source_include = Request._sourceInclude.join(',')
+    }
+    if (Request.q) {
+      httpQuery.q = Request.q
+    }
+
+    if (!Request.index || !Request.type) {
+      throw new Error('Query.index and Query.type are required arguments for executing ElasticSearch query')
+    }
+    if (config.elasticsearch.queryMethod === 'GET') {
+      httpQuery.request = JSON.stringify(ElasticsearchQueryBody)
+    }
+    url = url + '/' + encodeURIComponent(Request.index) + '/' + encodeURIComponent(Request.type) + '/_search'
+    url = url + '?' + queryString.stringify(httpQuery)
+    return fetch(url, { method: config.elasticsearch.queryMethod,
+      mode: 'cors',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: config.elasticsearch.queryMethod === 'POST' ? JSON.stringify(ElasticsearchQueryBody) : null
+    })
+      .then(resp => { return resp.json() })
+      .catch(error => {
+        throw new Error('FetchError in request to ES: ' + error.toString())
+      })
+  }
+}

--- a/src/themes/icmaa-imp/components/core/ProductListingWidget.vue
+++ b/src/themes/icmaa-imp/components/core/ProductListingWidget.vue
@@ -45,33 +45,19 @@ export default {
     }
   },
   async mounted () {
+    let size = this.limit
+
+    // If products are not enough because of different limit than product count in state, load more.
     if (this.products.length < this.limit) {
-      // If products are not enough because of different limit than product count in state, load more.
-      await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
-        categoryId: this.categoryId,
-        cluster: this.cluster,
-        size: this.limit - this.products.length,
-        sort: this.sort
-      })
-    } else {
-      // If no products there yet
-      await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
-        categoryId: this.categoryId,
-        cluster: this.cluster,
-        size: this.limit,
-        sort: this.sort
-      })
+      size = this.limit - this.products.length
     }
 
-    // If not enough cluster items found, load regular ones
-    // ! This is a workaround for missing should/or filter of quickSearchByQuery
-    if (this.cluster && this.products.length < this.limit) {
-      await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
-        categoryId: this.categoryId,
-        size: this.limit - this.products.length,
-        sort: this.sort
-      })
-    }
+    await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
+      categoryId: this.categoryId,
+      cluster: this.cluster,
+      sort: this.sort,
+      size
+    })
   }
 }
 </script>

--- a/src/themes/icmaa-imp/components/core/ProductListingWidget.vue
+++ b/src/themes/icmaa-imp/components/core/ProductListingWidget.vue
@@ -30,7 +30,7 @@ export default {
     },
     sort: {
       type: String,
-      default: 'created_at:asc'
+      default: 'online:desc'
     }
   },
   computed: {


### PR DESCRIPTION
* Maybe this is becoming a core feature – if the pull-request https://github.com/DivanteLtd/vue-storefront/pull/3834 is going to be approved
* Change queries of product-list-widget on homepage