### PR TITLE
Bugfix // Add IntlPolyfill support for NodeJS

### DIFF
--- a/src/modules/icmaa-config/helpers/price.ts
+++ b/src/modules/icmaa-config/helpers/price.ts
@@ -1,0 +1,37 @@
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+
+const formatValue = (value, locale) => {
+  const price = Math.abs(parseFloat(value))
+  const formatter = new Intl.NumberFormat(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  return formatter.format(price)
+}
+
+const applyCurrencySign = (formattedPrice, { currencySign, priceFormat }) => {
+  return priceFormat.replace('{sign}', currencySign).replace('{amount}', formattedPrice)
+}
+
+/**
+ * Converts number to price string
+ * @param {Number} value
+ */
+export function price (value) {
+  if (isNaN(value)) {
+    return value
+  }
+  const storeView = currentStoreView()
+  if (!storeView.i18n) {
+    return value;
+  }
+
+  // @ts-ignore
+  const { defaultLocale, currencySign, priceFormat } = storeView.i18n
+
+  const formattedValue = formatValue(value, defaultLocale)
+  const valueWithSign = applyCurrencySign(formattedValue, { currencySign, priceFormat })
+
+  if (value >= 0) {
+    return valueWithSign
+  } else {
+    return '-' + valueWithSign
+  }
+}

--- a/src/modules/icmaa-config/index.ts
+++ b/src/modules/icmaa-config/index.ts
@@ -7,6 +7,8 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
+import { checkForIntlPolyfill } from './lib/intl'
+
 export const cacheStorageKey = 'icmaa-config'
 export const cacheStorage = StorageManager.init(cacheStorageKey, false)
 
@@ -35,6 +37,12 @@ export const IcmaaExtendedConfigModule: StorefrontModule = function ({ store }) 
           Logger.debug('Set build time:', 'icmaa-config', envBuildtime)()
           await configStorage.setItem('buildtime', envBuildtime)
         }
+      })
+    }
+
+    if (isServer) {
+      coreHooks.afterAppInit(async () => {
+        await checkForIntlPolyfill()
       })
     }
   }

--- a/src/modules/icmaa-config/lib/intl.ts
+++ b/src/modules/icmaa-config/lib/intl.ts
@@ -1,0 +1,17 @@
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import areIntlLocalesSupported from 'intl-locales-supported'
+
+export const importIntlPolyfill = async () => {
+  const IntlPolyfill = await import('intl')
+  global.Intl = IntlPolyfill.default
+}
+
+export const checkForIntlPolyfill = async () => {
+  if (global.Intl) {
+    if (!areIntlLocalesSupported(currentStoreView().i18n.defaultLocale)) {
+      await importIntlPolyfill()
+    }
+  } else {
+    await importIntlPolyfill()
+  }
+}

--- a/src/modules/icmaa-config/package.json
+++ b/src/modules/icmaa-config/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "i18n-iso-countries": "^4.3.1",
+    "intl": "^1.2.5",
+    "intl-locales-supported": "^1.8.4",
     "vuelidate": "^0.7.4"
   }
 }

--- a/src/themes/icmaa-imp/components/core/ProductTile.vue
+++ b/src/themes/icmaa-imp/components/core/ProductTile.vue
@@ -14,15 +14,15 @@
       </p>
       <p>
         <span class="price-original t-text-base-light t-line-through t-mr-2" v-if="product.special_price && parseFloat(product.original_price_incl_tax) > 0">
-          {{ product.original_price_incl_tax | price }}
+          {{ price(product.original_price_incl_tax) }}
         </span>
         <span class="price-special t-text-sale t-font-bold" v-if="product.special_price && parseFloat(product.special_price) > 0">
           <span v-if="hasMultiplePrices" v-text="$t('as low as')" />
-          {{ product.price_incl_tax | price }}
+          {{ price(product.price_incl_tax) }}
         </span>
         <span class="price t-text-base-dark t-font-bold" v-if="!product.special_price && parseFloat(product.price_incl_tax) > 0">
           <span v-if="hasMultiplePrices" v-text="$t('as low as')" />
-          {{ product.price_incl_tax | price }}
+          {{ price(product.price_incl_tax) }}
         </span>
       </p>
     </router-link>

--- a/src/themes/icmaa-imp/mixins/product/priceMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/priceMixin.ts
@@ -1,3 +1,5 @@
+import { price } from '@vue-storefront/core/filters/price'
+
 export default {
   computed: {
     hasMultiplePrices () {
@@ -20,6 +22,11 @@ export default {
         })
       }
       return false
+    }
+  },
+  methods: {
+    price (value) {
+      return price(value)
     }
   }
 }

--- a/src/themes/icmaa-imp/mixins/product/priceMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/priceMixin.ts
@@ -1,4 +1,4 @@
-import { price } from '@vue-storefront/core/filters/price'
+import { price } from 'icmaa-config/helpers/price'
 
 export default {
   computed: {
@@ -25,8 +25,6 @@ export default {
     }
   },
   methods: {
-    price (value) {
-      return price(value)
-    }
+    price
   }
 }

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -35,16 +35,16 @@
 
               <div v-if="product.type_id !== 'grouped'" class="price t-mt-5 t-mb-8 t-text-1xl">
                 <template v-if="product.special_price && product.price_incl_tax && product.original_price_incl_tax">
-                  <span class="t-text-base-tone t-line-through">{{ product.original_price_incl_tax * product.qty | price }}</span>
+                  <span class="t-text-base-tone t-line-through">{{ price(product.original_price_incl_tax * product.qty) }}</span>
                   &nbsp;
                   <span class="t-text-sale t-font-bold">
                     <span v-if="hasMultiplePrices" v-text="$t('as low as')" class="t-text-sm" />
-                    {{ product.price_incl_tax * product.qty | price }}
+                    {{ price(product.price_incl_tax * product.qty) }}
                   </span>
                 </template>
                 <span class="t-font-bold" v-if="!product.special_price && product.price_incl_tax">
                   <span v-if="hasMultiplePrices" v-text="$t('as low as')" class="t-text-sm" />
-                  {{ product.qty > 0 ? product.price_incl_tax * product.qty : product.price_incl_tax | price }}
+                  {{ price(product.qty > 0 ? product.price_incl_tax * product.qty : product.price_incl_tax) }}
                 </span>
                 <div class="t-mt-1 t-text-xs t-text-base-light" v-html="taxDisclaimer" />
               </div>


### PR DESCRIPTION
* Include price rendering as method because filters aren't used on SSR
* Add IntlPolyfill support for NodeJS (DivanteLtd#3837, DivanteLtd#3836)
  * We can undo this commit if the PR #3837 is merged