### PR TITLE
Bugfix // Missing categories if logoline fetches them using `loadCategories`

### DIFF
--- a/src/modules/icmaa-catalog/store/category/actions.ts
+++ b/src/modules/icmaa-catalog/store/category/actions.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import { ActionTree } from 'vuex'
 import RootState from '@vue-storefront/core/types/RootState'
 import CategoryState from '@vue-storefront/core/modules/catalog-next/store/category/CategoryState'
@@ -7,6 +8,7 @@ import { DataResolver } from '@vue-storefront/core/data-resolver/types/DataResol
 import { router } from '@vue-storefront/core/app'
 import { products } from 'config'
 import { changeFilterQuery } from '@vue-storefront/core/modules/catalog-next/helpers/filterHelpers'
+import * as orgTypes from '@vue-storefront/core/modules/catalog-next/store/category/mutation-types'
 
 import extendedCoreActions from './actions/index'
 
@@ -35,6 +37,18 @@ const actions: ActionTree<CategoryState, RootState> = {
       currentQuery = changeFilterQuery({currentQuery, filterVariant})
     })
     await dispatch('changeRouterFilterParameters', currentQuery)
+  },
+  async findCategoriesWithoutBlacklisting ({ dispatch, commit }, categorySearchOptions: DataResolver.CategorySearchOptions): Promise<Category[]> {
+    const categories = await dispatch('findCategories', categorySearchOptions)
+    if (Vue.prototype.$cacheTags) {
+      categories.forEach(category => {
+        Vue.prototype.$cacheTags.add(`C${category.id}`)
+      })
+    }
+
+    commit(orgTypes.CATEGORY_ADD_CATEGORIES, categories)
+
+    return categories
   }
 }
 

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLine.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LogoLine.vue
@@ -112,7 +112,7 @@ export default {
       }
 
       await this.$store.dispatch(
-        'category-next/loadCategories',
+        'category-next/findCategoriesWithoutBlacklisting',
         { filters, size: this.limit, onlyActive: true }
       )
 


### PR DESCRIPTION
* If we use `loadCategories` and items are not fulfill the filter, they… will land in not found storage array and won't be triggered again
* Therefore we are using a similar, own action without not-found population