### PR TITLE
Bugfix // Sidebar/Modal body-scroll-lock and overlay vs. history-back button

### DIFF
--- a/src/themes/icmaa-imp/components/core/Modal.vue
+++ b/src/themes/icmaa-imp/components/core/Modal.vue
@@ -105,7 +105,14 @@ export default {
     },
     close () {
       this.toggle(false)
+    },
+    onHistoryBack () {
+      this.close()
     }
+  },
+  mounted () {
+    // Close this if browser-back button is called
+    window.addEventListener('popstate', this.onHistoryBack)
   },
   beforeMount () {
     this.$bus.$on('modal-toggle', this.onToggle)
@@ -116,6 +123,8 @@ export default {
     this.$bus.$off('modal-toggle', this.onToggle)
     this.$bus.$off('modal-show', this.onShow)
     this.$bus.$off('modal-hide', this.onHide)
+
+    window.removeEventListener('popstate', this.onHistoryBack)
   }
 }
 </script>

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -66,6 +66,13 @@ export default {
   created () {
     this.getComponent()
   },
+  mounted () {
+    // Close this if browser-back button is called
+    window.addEventListener('popstate', this.onHistoryBack)
+  },
+  destroyed () {
+    window.removeEventListener('popstate', this.onHistoryBack)
+  },
   methods: {
     getComponent () {
       this.component = () => ({
@@ -74,6 +81,9 @@ export default {
         error: LoadingError,
         timeout: 3000
       })
+    },
+    onHistoryBack () {
+      this.$store.dispatch('ui/closeAll')
     }
   },
   computed: {

--- a/src/themes/icmaa-imp/components/core/blocks/Wishlist/Wishlist.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Wishlist/Wishlist.vue
@@ -37,9 +37,6 @@ export default {
       default: () => {}
     }
   },
-  created () {
-    window.addEventListener('popstate', this.closeSidebar)
-  },
   methods: {
     clearWishlist () {
       this.$store.dispatch('notification/spawnNotification', {
@@ -54,9 +51,6 @@ export default {
         action2: { label: this.$t('Cancel'), action: 'close' },
         hasNoTimeout: true
       })
-    },
-    closeSidebar () {
-      this.$store.dispatch('ui/closeAll')
     }
   },
   mixins: [Wishlist]

--- a/src/themes/icmaa-imp/components/core/blocks/Wishlist/Wishlist.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Wishlist/Wishlist.vue
@@ -37,6 +37,9 @@ export default {
       default: () => {}
     }
   },
+  created () {
+    window.addEventListener('popstate', this.closeSidebar)
+  },
   methods: {
     clearWishlist () {
       this.$store.dispatch('notification/spawnNotification', {
@@ -51,6 +54,9 @@ export default {
         action2: { label: this.$t('Cancel'), action: 'close' },
         hasNoTimeout: true
       })
+    },
+    closeSidebar () {
+      this.$store.dispatch('ui/closeAll')
     }
   },
   mixins: [Wishlist]


### PR DESCRIPTION
* If you have a open sidebar or modal and use the history-back button of the browser, the modal will disappear but the body-scroll-lock won't be disabled
* The `popstate` window event is the solution for that – we integrated it into the modal and sidebar component