### PR TITLE
Add department as filter to ProductListingWidget

### DIFF
--- a/src/modules/icmaa-category/components/core/ProductListingWidget.vue
+++ b/src/modules/icmaa-category/components/core/ProductListingWidget.vue
@@ -39,10 +39,10 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('icmaaCategory', ['getProductListingWidgetByCategoryId']),
+    ...mapGetters('icmaaCategory', ['getProductListingWidget']),
     ...mapGetters({ cluster: 'user/getCluster' }),
     products () {
-      const products = this.getProductListingWidgetByCategoryId(this.categoryId)
+      const products = this.getProductListingWidget(this.categoryId, this.filter)
       if (!products) {
         return []
       }
@@ -60,7 +60,6 @@ export default {
 
       await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
         categoryId: this.categoryId,
-        departmentId: this.departmentId,
         cluster: this.cluster,
         filter: this.filter,
         sort: this.sort,

--- a/src/modules/icmaa-category/components/core/ProductListingWidget.vue
+++ b/src/modules/icmaa-category/components/core/ProductListingWidget.vue
@@ -28,9 +28,10 @@ export default {
       type: Number,
       required: true
     },
-    departmentId: {
-      type: Number,
-      required: true // prop as option
+    filter: {
+      type: [Object, Boolean],
+      required: false,
+      default: false
     },
     sort: {
       type: String,
@@ -61,6 +62,7 @@ export default {
         categoryId: this.categoryId,
         departmentId: this.departmentId,
         cluster: this.cluster,
+        filter: this.filter,
         sort: this.sort,
         size
       })

--- a/src/modules/icmaa-category/components/core/ProductListingWidget.vue
+++ b/src/modules/icmaa-category/components/core/ProductListingWidget.vue
@@ -28,6 +28,10 @@ export default {
       type: Number,
       required: true
     },
+    departmentId: {
+      type: Number,
+      required: true // prop as option
+    },
     sort: {
       type: String,
       default: 'online:desc'
@@ -55,6 +59,7 @@ export default {
 
       await this.$store.dispatch('icmaaCategory/loadProductListingWidgetProducts', {
         categoryId: this.categoryId,
+        departmentId: this.departmentId,
         cluster: this.cluster,
         sort: this.sort,
         size

--- a/src/modules/icmaa-category/helpers/index.ts
+++ b/src/modules/icmaa-category/helpers/index.ts
@@ -3,6 +3,7 @@ import { Category } from '@vue-storefront/core/modules/catalog-next/types/Catego
 import { SearchResponse } from '@vue-storefront/core/types/search/SearchResponse'
 import { quickSearchByQuery } from '@vue-storefront/core/lib/search'
 import { entities } from 'config'
+import { getObjectHash } from 'icmaa-config/helpers/hash'
 
 export const fetchCategoryById = ({ parentId }): Promise<SearchResponse> => {
   let searchQuery = new SearchQuery()
@@ -40,4 +41,8 @@ export const extractPrefix = (name) => name.replace(SORT_PREFIX_REGEXP, '')
 export const sortByLetter = (a: Category, b: Category) => {
   const [aName, bName] = [extractPrefix(a.name), extractPrefix(b.name)]
   return aName === bName ? 0 : aName < bName ? -1 : 1
+}
+
+export const getFilterHash = (filter: Record<string, any>|boolean) => {
+  return filter !== false ? getObjectHash(filter as Record<string, any>) : false
 }

--- a/src/modules/icmaa-category/store/actions.ts
+++ b/src/modules/icmaa-category/store/actions.ts
@@ -37,8 +37,8 @@ const actions: ActionTree<CategoryState, RootState> = {
       return { parent, list: list as Category[] }
     }
   },
-  async loadProductListingWidgetProducts ({ state, commit, dispatch }, params: { categoryId: number, cluster: any, size: number, sort: string|string[] }): Promise<ProductListingWidgetState> {
-    let { categoryId, cluster, size, sort } = params
+  async loadProductListingWidgetProducts ({ state, commit, dispatch }, params: { categoryId: number, departmentId: number, cluster: any, size: number, sort: string|string[] }): Promise<ProductListingWidgetState> {
+    let { categoryId, departmentId, cluster, size, sort } = params
 
     if (state.productListingWidget.find(i => i.parent === categoryId && i.cluster === cluster && i.list.length >= size)) {
       return
@@ -50,6 +50,7 @@ const actions: ActionTree<CategoryState, RootState> = {
       .applyFilter({ key: 'visibility', value: { in: [2, 3, 4] } })
       .applyFilter({ key: 'status', value: { in: [0, 1] } })
       .applyFilter({ key: 'category_ids', value: { in: [categoryId] } })
+      .applyFilter({ key: 'department', value: { in: [departmentId] } })
 
     if (cluster) {
       cluster = parseInt(cluster)
@@ -59,7 +60,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     }
 
     return dispatch('product/findProducts', { query, size, sort }, { root: true }).then(products => {
-      const payload = { parent: categoryId, list: products.items, cluster }
+      const payload = { parent: categoryId, departmentId, list: products.items, cluster }
       commit(types.ICMAA_CATEGORY_LIST_ADD_PRODUCT, payload)
       return payload
     })

--- a/src/modules/icmaa-category/store/actions.ts
+++ b/src/modules/icmaa-category/store/actions.ts
@@ -6,6 +6,7 @@ import * as types from './mutation-types'
 import * as catTypes from '@vue-storefront/core/modules/catalog-next/store/category/mutation-types'
 import { fetchCategoryById, fetchChildCategories } from '../helpers'
 import { SearchQuery } from 'storefront-query-builder'
+import { getFilterHash } from '../helpers'
 
 import forEach from 'lodash-es/forEach'
 import { Logger } from '@vue-storefront/core/lib/logger'
@@ -52,7 +53,8 @@ const actions: ActionTree<CategoryState, RootState> = {
       .applyFilter({ key: 'status', value: { in: [0, 1] } })
       .applyFilter({ key: 'category_ids', value: { in: [categoryId] } })
 
-    if (filter) {
+    let filterHash = getFilterHash(filter)
+    if (filter !== false) {
       forEach(filter, (value, key) => {
         value = { in: [value] }
         query.applyFilter({ key, value })
@@ -67,7 +69,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     }
 
     return dispatch('product/findProducts', { query, size, sort }, { root: true }).then(products => {
-      const payload = { parent: categoryId, list: products.items, cluster }
+      const payload = { parent: categoryId, list: products.items, cluster, filter: filterHash }
       commit(types.ICMAA_CATEGORY_LIST_ADD_PRODUCT, payload)
       return payload
     })

--- a/src/modules/icmaa-category/store/actions.ts
+++ b/src/modules/icmaa-category/store/actions.ts
@@ -69,7 +69,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     }
 
     return dispatch('product/findProducts', { query, size, sort }, { root: true }).then(products => {
-      const payload = { parent: categoryId, list: products.items, cluster, filter: filterHash }
+      const payload = { parent: categoryId, list: products.items, cluster, filterHash }
       commit(types.ICMAA_CATEGORY_LIST_ADD_PRODUCT, payload)
       return payload
     })

--- a/src/modules/icmaa-category/store/getters.ts
+++ b/src/modules/icmaa-category/store/getters.ts
@@ -33,7 +33,7 @@ const getters: GetterTree<CategoryState, RootState> = {
       cluster = parseInt(rootGetters['user/getCluster'])
     }
 
-    return state.productListingWidget.find(i => i.parent === parent && i.cluster === cluster && i.filter === getFilterHash(filter))
+    return state.productListingWidget.find(i => i.parent === parent && i.cluster === cluster && i.filterHash === getFilterHash(filter))
   }
 }
 

--- a/src/modules/icmaa-category/store/getters.ts
+++ b/src/modules/icmaa-category/store/getters.ts
@@ -1,7 +1,7 @@
 import { GetterTree } from 'vuex'
 import CategoryState, { CategoryStateListItem, ProductListingWidgetState } from '../types/CategoryState'
 import RootState from '@vue-storefront/core/types/RootState'
-import { sortByLetter } from '../helpers'
+import { sortByLetter, getFilterHash } from '../helpers'
 
 const getters: GetterTree<CategoryState, RootState> = {
   lists: state => state.lists,
@@ -27,14 +27,13 @@ const getters: GetterTree<CategoryState, RootState> = {
 
     return false
   },
-  getProductListingWidget: (state): ProductListingWidgetState[] => state.productListingWidget,
-  getProductListingWidgetByCategoryId: (state, getters, RootState, rootGetters) => (parent: number): ProductListingWidgetState => {
+  getProductListingWidget: (state, getters, RootState, rootGetters) => (parent: number, filter: Record<string, any>|boolean = false): ProductListingWidgetState => {
     let cluster = rootGetters['user/getCluster']
     if (cluster !== false) {
       cluster = parseInt(rootGetters['user/getCluster'])
     }
 
-    return state.productListingWidget.find(i => i.parent === parent && i.cluster === cluster)
+    return state.productListingWidget.find(i => i.parent === parent && i.cluster === cluster && i.filter === getFilterHash(filter))
   }
 }
 

--- a/src/modules/icmaa-category/store/mutations.ts
+++ b/src/modules/icmaa-category/store/mutations.ts
@@ -12,7 +12,7 @@ const mutations: MutationTree<CategoryListState> = {
     }
   },
   [types.ICMAA_CATEGORY_LIST_ADD_PRODUCT] (state, payload: ProductListingWidgetState) {
-    let list = state.productListingWidget.find(i => i.parent === payload.parent && i.cluster === payload.cluster)
+    let list = state.productListingWidget.find(i => i.parent === payload.parent && i.cluster === payload.cluster && i.filter === payload.filter)
     if (list) {
       const newProductids = payload.list.map(p => p.id).filter(id => !list.list.map(p => p.id).includes(id))
       list.list.push(...payload.list.filter(p => newProductids.includes(p.id)))

--- a/src/modules/icmaa-category/store/mutations.ts
+++ b/src/modules/icmaa-category/store/mutations.ts
@@ -12,7 +12,7 @@ const mutations: MutationTree<CategoryListState> = {
     }
   },
   [types.ICMAA_CATEGORY_LIST_ADD_PRODUCT] (state, payload: ProductListingWidgetState) {
-    let list = state.productListingWidget.find(i => i.parent === payload.parent && i.cluster === payload.cluster && i.filter === payload.filter)
+    let list = state.productListingWidget.find(i => i.parent === payload.parent && i.cluster === payload.cluster && i.filterHash === payload.filterHash)
     if (list) {
       const newProductids = payload.list.map(p => p.id).filter(id => !list.list.map(p => p.id).includes(id))
       list.list.push(...payload.list.filter(p => newProductids.includes(p.id)))

--- a/src/modules/icmaa-category/types/CategoryState.ts
+++ b/src/modules/icmaa-category/types/CategoryState.ts
@@ -19,6 +19,6 @@ export interface CategoryStateListItemHydrated {
 export interface ProductListingWidgetState {
   parent: number,
   cluster: number|boolean,
-  filter: string|boolean,
+  filterHash: string|boolean,
   list: Product[]
 }

--- a/src/modules/icmaa-category/types/CategoryState.ts
+++ b/src/modules/icmaa-category/types/CategoryState.ts
@@ -19,5 +19,6 @@ export interface CategoryStateListItemHydrated {
 export interface ProductListingWidgetState {
   parent: number,
   cluster: number|boolean,
+  filter: string|boolean,
   list: Product[]
 }

--- a/src/modules/icmaa-cms/data-resolver/Task.ts
+++ b/src/modules/icmaa-cms/data-resolver/Task.ts
@@ -1,4 +1,5 @@
 import { cacheStorage as cache } from '../'
+import { getHash } from 'icmaa-config/helpers/hash'
 
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import { Logger } from '@vue-storefront/core/lib/logger'
@@ -10,8 +11,6 @@ import * as types from '../store/default/mutation-types'
 
 const createQueryString: Function = (params: Record<string, any>): string =>
   Object.keys(params).map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(params[key])).join('&')
-
-const getHash: Function = (s: string): number => Math.abs(s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0))
 
 const getTaskId: Function = (s: string): string => `task-${getHash(s)}`
 

--- a/src/modules/icmaa-config/helpers/hash.ts
+++ b/src/modules/icmaa-config/helpers/hash.ts
@@ -1,0 +1,3 @@
+export const getHash: Function = (s: string): number => Math.abs(s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0))
+
+export const getObjectHash = (o: object): string => getHash(JSON.stringify(o))

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -10,8 +10,10 @@
       </div>
     </lazy-hydrate>
     <lazy-hydrate when-visible>
+      <product-listing-widget :category-id="3278" :filter="{ department: 5 }" />
+    </lazy-hydrate>
+    <lazy-hydrate when-visible>
       <product-listing-widget :category-id="3278" :filter="{ department: 6 }" />
-      <product-listing-widget :category-id="3278" :filter="{ department: 8 }" />
     </lazy-hydrate>
   </div>
 </template>

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -10,10 +10,10 @@
       </div>
     </lazy-hydrate>
     <lazy-hydrate when-visible>
-      <product-listing-widget :category-id="3278" :filter="{ department: 5 }" />
+      <product-listing-widget :category-id="3278" :filter="{ department: 6 }" />
     </lazy-hydrate>
     <lazy-hydrate when-visible>
-      <product-listing-widget :category-id="3278" :filter="{ department: 6 }" />
+      <product-listing-widget :category-id="3278" :filter="{ department: 5 }" />
     </lazy-hydrate>
   </div>
 </template>

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -10,10 +10,7 @@
       </div>
     </lazy-hydrate>
     <lazy-hydrate when-visible>
-      <product-listing-widget :category-id="3278" />
-    </lazy-hydrate>
-    <lazy-hydrate when-visible>
-      <product-listing-widget :category-id="4251" />
+      <product-listing-widget :category-id="3278" :department-id="6" />
     </lazy-hydrate>
   </div>
 </template>

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -10,7 +10,8 @@
       </div>
     </lazy-hydrate>
     <lazy-hydrate when-visible>
-      <product-listing-widget :category-id="3278" :department-id="6" />
+      <product-listing-widget :category-id="3278" :filter="{ department: 6 }" />
+      <product-listing-widget :category-id="3278" :filter="{ department: 8 }" />
     </lazy-hydrate>
   </div>
 </template>


### PR DESCRIPTION
@cewald Funktioniert schon mal grundlegend. Aber man kann nicht zwei Widgets mit der identischen Kategorie und unterschiedlicher DepartmentId integrieren. 

Auf der Startseite sollen 4 Produkte aus Kategorie "New" aus Department "Merch" und 4 aus Department "Steetwear" angezeigt werden.