### PR TITLE
Add correct type matching to `getConfigurationMatchLevel`

### DIFF
--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -62,7 +62,7 @@ const getConfigurationMatchLevel = (configuration, variant): number => {
 
       return [].concat(configuration[configProperty])
         .map(f => toString(f.id))
-        .includes(variantPropertyId)
+        .includes(toString(variantPropertyId))
     })
     .filter(Boolean)
     .length

--- a/src/themes/icmaa-imp/mixins/product/optionsMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/optionsMixin.ts
@@ -102,10 +102,7 @@ export default {
      * @param option
      */
     isOptionAvailable (option) {
-      const confChildren = this.product.configurable_children.find(c => c[option.type] === option.id)
-      const sku = confChildren ? confChildren.sku : null
-      const currentConfig = Object.assign({}, this.configuration, { [option.type]: option }, { sku })
-
+      const currentConfig = Object.assign({}, this.configuration, { [option.type]: option })
       const variant = findConfigurableChildAsync({ product: this.product, configuration: currentConfig, availabilityCheck: true })
       return typeof variant !== 'undefined' && variant !== null && variant[option.type] === option.id
     }


### PR DESCRIPTION
* Otherwise the `AddToCartSidebar` component won't work because it cant find a valid configurable option caused by unequal type values (string vs number)
* It is caused by the refactoring of `getConfigurationMatchLevel`: 168f220dc1ee6b1cb15a2d581412dcdf296e9454
* PR #272 had the same cause – but it thought to need to solve it by adding the SKU, but that wasn't actually the cause