### PR TITLE
#187376 Bugfix for GTM tracking

### DIFF
--- a/src/modules/icmaa-external-checkout/index.ts
+++ b/src/modules/icmaa-external-checkout/index.ts
@@ -26,12 +26,14 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
     EventBus.$on('session-after-nonauthorized', async () => {
       const customerToken = Vue.$cookies.get('vsf_token_customer')
       const quoteToken = Vue.$cookies.get('vsf_token_quote')
+      const lastOrderToken = Vue.$cookies.get('vsf_token_lastorder')
 
-      if (!store.getters['user/isLoggedIn'] && (customerToken || quoteToken)) {
+      if (!store.getters['user/isLoggedIn'] && (customerToken || quoteToken || lastOrderToken)) {
         if (customerToken) {
           Logger.info('Customer token found in cookie – try to login:', 'external-checkout', customerToken)()
           store.dispatch('user/startSessionWithToken', customerToken).then(() => {
             Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
+            Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
           })
         }
 
@@ -39,6 +41,13 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
           Logger.info('Quote token found in cookie – try to reconnect with:', 'external-checkout', quoteToken)()
           store.dispatch('cart/reconnect', { token: quoteToken }).then(() => {
             Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
+          })
+        }
+
+        if (!customerToken && lastOrderToken) {
+          Logger.info('Last-order token found in cookie – try to load last order:', 'external-checkout', lastOrderToken)()
+          store.dispatch('user/loadLastOrderToHistory', { token: lastOrderToken }).then(() => {
+            Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
           })
         }
       }

--- a/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
+++ b/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
@@ -54,8 +54,11 @@ export default {
      * logged in when the beforeMount event hook is called. Otherwise the `checkout-success-last-order-loaded`
      * event won't ever be fired on first request because `isLoggedIn` is false.
      */
-    isLoggedIn (isLoggedIn) {
-      this.onLogin(isLoggedIn)
+    isLoggedIn (value) {
+      this.onLogin(value)
+    },
+    lastOrder () {
+      this.guestOrder()
     }
   },
   methods: {
@@ -68,6 +71,13 @@ export default {
     async onLogin (value) {
       if (value || this.isLoggedIn) {
         await this.$store.dispatch('user/refreshOrdersHistory', { resolvedFromCache: false })
+        this.$bus.$emit('checkout-success-last-order-loaded', this.lastOrder)
+      } else if (!value && !this.isLoggedIn) {
+        await this.$store.dispatch('user/loadLastOrderFromCache')
+      }
+    },
+    async guestOrder () {
+      if (!this.isLoggedIn && this.lastOrder) {
         this.$bus.$emit('checkout-success-last-order-loaded', this.lastOrder)
       }
     }

--- a/src/modules/icmaa-user/data-resolver/UserService.ts
+++ b/src/modules/icmaa-user/data-resolver/UserService.ts
@@ -1,0 +1,26 @@
+import { processLocalizedURLAddress } from '@vue-storefront/core/helpers'
+import { TaskQueue } from '@vue-storefront/core/lib/sync'
+import Task from '@vue-storefront/core/lib/sync/types/Task'
+import config from 'config'
+import getApiEndpointUrl from '@vue-storefront/core/helpers/getApiEndpointUrl'
+
+const headers = {
+  'Accept': 'application/json, text/plain, */*',
+  'Content-Type': 'application/json'
+}
+
+const getLastOrder = async (token: string): Promise<Task> =>
+  TaskQueue.execute({
+    url: processLocalizedURLAddress(
+      getApiEndpointUrl(config.users, 'last_order').replace('{{token}}', token)
+    ),
+    payload: {
+      method: 'GET',
+      mode: 'cors',
+      headers
+    }
+  })
+
+export const UserService: any = {
+  getLastOrder
+}


### PR DESCRIPTION
* Load last-order by JWT-Order-ID-Token stored inside a cookie when user returns from external checkout
* Connected to https://github.com/icmaa/vue-storefront-api/pull/60 & https://github.com/icmaa/shop-impericon/pull/1056