### PR TITLE
#199473 Remove token cookies in `icmaa-external-checkout`

### DIFF
--- a/src/modules/icmaa-external-checkout/index.ts
+++ b/src/modules/icmaa-external-checkout/index.ts
@@ -23,10 +23,26 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
       Vue.use(VueCookies)
     })
 
+    const getCookies = (): { customerToken: string, quoteToken: string, lastOrderToken: string } => {
+      return {
+        customerToken: Vue.$cookies.get('vsf_token_customer'),
+        quoteToken: Vue.$cookies.get('vsf_token_quote'),
+        lastOrderToken: Vue.$cookies.get('vsf_token_lastorder')
+      }
+    }
+
+    EventBus.$on('session-after-started', async () => {
+      const { customerToken, quoteToken, lastOrderToken } = getCookies()
+
+      if (store.getters['user/isLoggedIn'] && (customerToken || quoteToken || lastOrderToken)) {
+        Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
+        Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
+        Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
+      }
+    })
+
     EventBus.$on('session-after-nonauthorized', async () => {
-      const customerToken = Vue.$cookies.get('vsf_token_customer')
-      const quoteToken = Vue.$cookies.get('vsf_token_quote')
-      const lastOrderToken = Vue.$cookies.get('vsf_token_lastorder')
+      const { customerToken, quoteToken, lastOrderToken } = getCookies()
 
       if (!store.getters['user/isLoggedIn'] && (customerToken || quoteToken || lastOrderToken)) {
         if (customerToken) {
@@ -69,6 +85,10 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
         Logger.info('Remove Magento session-cookie', 'external-checkout', Vue.$cookies.get('frontend'))()
         Vue.$cookies.remove('frontend')
       }
+
+      Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
+      Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
+      Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
     })
   }
 


### PR DESCRIPTION
Remove token cookies on logout or if you already logged-in in `icmaa-external-checkout`:
* If you go to the checkout as a logged-in user and you return to the PWA, the token-cookies will be set
* If you then again log yourself out, those cookies won't be deleted and therfore will log you in again on   the next reload
* So we delete them on logout or if you are already logged-in on session-start