### PR TITLE
#187376 Improve DataLayer of `icmaa-google-tag-manager`

### DIFF
--- a/src/modules/icmaa-google-tag-manager/mixins/checkoutSuccessGtm.ts
+++ b/src/modules/icmaa-google-tag-manager/mixins/checkoutSuccessGtm.ts
@@ -61,19 +61,19 @@ export default {
           currencyCode: currencyCode,
           purchase: {
             actionField: {
-              transactionId: this.orderId,
-              transactionAffiliation: this.orderStoreName,
-              transactionTotal: this.orderGrandTotal,
-              transactionTax: this.orderTaxAmount,
-              transactionShipping: this.orderShippingDescription,
+              id: this.orderId,
+              affiliation: this.orderStoreName,
+              revenue: this.orderGrandTotal,
+              tax: this.orderTaxAmount,
+              shipping: this.orderShippingDescription,
               payment: this.paymentMethod,
               coupon: this.couponCode,
               couponrule: this.couponCodeRule
             },
-            transactionProducts: this.singleOrderItems
+            products: this.singleOrderItems
           }
         }
-      });
+      })
 
       this.$store.dispatch('icmaaGoogleTagManager/setLastOrderId', this.orderId)
     }

--- a/src/modules/icmaa-google-tag-manager/mixins/checkoutSuccessGtm.ts
+++ b/src/modules/icmaa-google-tag-manager/mixins/checkoutSuccessGtm.ts
@@ -3,6 +3,8 @@ import VueGtm from 'vue-gtm'
 import { mapGetters } from 'vuex'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { googleTagManager } from 'config'
+import { formatValue } from 'icmaa-config/helpers/price'
+import { toDate } from 'icmaa-config/helpers/datetime'
 import AbstractMixin from './abstractMixin'
 
 export default {
@@ -16,16 +18,25 @@ export default {
       return this.ordersHistory.length > 0 ? this.ordersHistory[0] : false
     },
     orderId () {
-      return this.order.increment_id || this.order.id
+      return this.order.increment_id || this.order.id ? (this.order.increment_id || this.order.id).toString() : null
     },
     orderStoreName () {
       return this.order.store_name
     },
+    orderDate () {
+      return toDate(this.order.created_at, 'YYYY-MM-DD HH:MM:ss')
+    },
     orderGrandTotal () {
-      return this.order.grand_total
+      return formatValue(this.order.grand_total, 'en-US')
+    },
+    orderSubTotal () {
+      return formatValue(this.order.subtotal, 'en-US')
     },
     orderTaxAmount () {
-      return this.order.tax_amount
+      return formatValue(this.order.tax_amount, 'en-US')
+    },
+    orderShippingAmount () {
+      return formatValue(this.order.shipping_amount, 'en-US')
     },
     orderShippingDescription () {
       return this.order.shipping_description
@@ -34,7 +45,7 @@ export default {
       return this.order.payment.additional_information[0]
     },
     couponCode () {
-      return this.order.coupon_code
+      return this.order.coupon_code ? String(this.order.coupon_code) : null
     },
     couponCodeRule () {
       return this.order.coupon_rule_name
@@ -55,8 +66,23 @@ export default {
       const storeView = currentStoreView()
       const currencyCode = storeView.i18n.currencyCode
 
+      const dataLayer = {
+        'order-id': this.orderId,
+        'order-date': this.orderDate,
+        'order-website': this.orderStoreName,
+        'order-total': this.orderGrandTotal,
+        'order-subtotal': this.orderSubTotal,
+        'order-tax': this.orderTaxAmount,
+        'order-shipping': this.orderShippingAmount,
+        'order-shipping-method': this.orderShippingDescription,
+        'order-payment': this.paymentMethod,
+        'order-currency-code': currencyCode,
+        'order-promo-code': this.couponCode
+      }
+
       GTM.trackEvent({
         event: 'icmaa-checkout-success-view',
+        ...dataLayer,
         ecommerce: {
           currencyCode: currencyCode,
           purchase: {

--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -63,7 +63,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
           if (value) {
             switch (attributeType) {
               case 'price':
-                product[attributeName] = formatValue(value)
+                product[attributeName] = formatValue(value, 'en-US')
                 break
               case 'attribute':
                 product[attributeName] = rootGetters['attribute/getOptionLabel']({ attributeKey: attributeField, optionId: value })


### PR DESCRIPTION
* Revert "#187376 Change key-names in DataLayer of `icmaa-google-tag-manager` (#307)"
* In order to have the same results as in magento we try map the datatypes and contents of the datalayer as same as in magento