### PR TITLE
#199755 Improve session handling during external-checkout

### DIFF
--- a/src/modules/icmaa-external-checkout/helper/index.ts
+++ b/src/modules/icmaa-external-checkout/helper/index.ts
@@ -20,7 +20,7 @@ export const getExternalCheckoutUrl = (): string => {
     shopUrl = store.url.startsWith('/') ? shopUrl + store.url : store.url
   }
 
-  const url = shopUrl + '/vue/cart/sync/token'
+  const url = shopUrl + '/vue/cart/sync'
   const query: { token: string, cart: string } = {
     token: userToken,
     cart: cartToken

--- a/src/modules/icmaa-external-checkout/helper/index.ts
+++ b/src/modules/icmaa-external-checkout/helper/index.ts
@@ -1,5 +1,6 @@
 import rootStore from '@vue-storefront/core/store'
 import config from 'config'
+import queryString from 'query-string'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { isServer } from '@vue-storefront/core/helpers'
 
@@ -19,7 +20,13 @@ export const getExternalCheckoutUrl = (): string => {
     shopUrl = store.url.startsWith('/') ? shopUrl + store.url : store.url
   }
 
-  return shopUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken
+  const url = shopUrl + '/vue/cart/sync/token'
+  const query: { token: string, cart: string } = {
+    token: userToken,
+    cart: cartToken
+  }
+
+  return queryString.stringifyUrl({ url, query })
 }
 
 export function getRedirectToExternalCheckoutUrl (routeName: string): string|boolean {

--- a/src/modules/icmaa-user/index.ts
+++ b/src/modules/icmaa-user/index.ts
@@ -1,3 +1,4 @@
+import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { extendStore } from '@vue-storefront/core/helpers'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
@@ -13,6 +14,12 @@ export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store
     if (mutation.type.endsWith(types.USER_ADD_SESSION_DATA)) {
       StorageManager.get('user').setItem('session-data', state.user.sessionData)
         .catch((reason) => { console.error(reason) })
+    }
+  })
+
+  EventBus.$on('session-after-started', async () => {
+    if (!store.getters['user/isLoggedIn'] && store.getters['user/getCustomer']) {
+      return store.dispatch('user/logout', { silent: true })
     }
   })
 

--- a/src/modules/icmaa-user/store/getters.ts
+++ b/src/modules/icmaa-user/store/getters.ts
@@ -1,11 +1,11 @@
 import { GetterTree } from 'vuex'
 import RootState from '@vue-storefront/core/types/RootState'
 import UserState from '../types/UserState'
-import UserProfile from '../types/UserProfile'
 
 import isEmpty from 'lodash-es/isEmpty'
 
 const getters: GetterTree<UserState, RootState> = {
+  isLoggedIn: (state): boolean => !isEmpty(state.current) && !isEmpty(state.token),
   getCustomer: (state) => state.current,
   getCluster: (state): string|false => {
     return (!isEmpty(state.sessionData) && state.sessionData.cluster)


### PR DESCRIPTION
* Attach checkout-url tokens as query-string parameters using `query-string`
* Log user out and clear cart if there is no customer token in state after session-start