### PR TITLE
#200014 Improve user-feedback in category filter sidebar

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -8,13 +8,9 @@
       v-if="isOpen"
     >
       <div class="submenu-wrapper t-relative">
-        <transition :name="sidebarLength > 0 || (sidebarLength === 1 && sidebarAnimation) ? 'slide-right' : ''">
-          <component :is="component" @close="$emit('close')" @reload="getComponent" v-show="sidebarLength === 0 || (sidebarLength === 1 && sidebarAnimation)" />
-        </transition>
+        <component :is="component" @close="$emit('close')" @reload="getComponent" v-show="!hasSubmenu" :key="'sidebar-home'" />
         <template v-for="(item, i) in sidebarPath">
-          <transition :name="item.animation" :appear="item.appear" :key="'animation-' + i">
-            <submenu :key="'submenu-' + i" :index="i" :async-component="item.component" v-show="item.visible" />
-          </transition>
+          <submenu :key="'submenu-' + i" :index="i" :async-component="item.component" />
         </template>
       </div>
     </div>
@@ -94,8 +90,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      sidebarPath: 'ui/getSidebarPath',
-      sidebarAnimation: 'ui/getSidebarAnimation'
+      sidebarPath: 'ui/getSidebarPath'
     }),
     hasSubmenu () {
       return this.sidebarPath.length > 0
@@ -107,7 +102,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import "~theme/css/animations/transitions";
 @import '~theme/css/base/global_vars';
 $z-index-modal: map-get($z-index, modal);
@@ -132,13 +127,16 @@ $z-index-modal: map-get($z-index, modal);
 .left-sidebar,
 .right-sidebar {
   top: 0;
-  z-index: $z-index-modal;
   height: 100vh;
   max-height: 100vh;
-  width: 460px;
   overflow: auto;
 
-  &.wide {
+  &, .sidebar-menu .header {
+    z-index: $z-index-modal;
+    width: 460px;
+  }
+
+  &.wide, &.wide .sidebar-menu .header {
     width: 800px;
   }
 

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -7,9 +7,15 @@
       ref="sidebar"
       v-if="isOpen"
     >
-      <div class="submenu-wrapper" :style="{ ...translateX }">
-        <component :is="component" @close="$emit('close')" @reload="getComponent" />
-        <submenu v-for="(item, i) in sidebarPath" :key="i" :index="i" :async-component="item.component" />
+      <div class="submenu-wrapper t-relative">
+        <transition :name="sidebarLength > 0 || (sidebarLength === 1 && sidebarAnimation) ? 'slide-right' : ''">
+          <component :is="component" @close="$emit('close')" @reload="getComponent" v-show="sidebarLength === 0 || (sidebarLength === 1 && sidebarAnimation)" />
+        </transition>
+        <template v-for="(item, i) in sidebarPath">
+          <transition :name="item.animation" :appear="item.appear" :key="'animation-' + i">
+            <submenu :key="'submenu-' + i" :index="i" :async-component="item.component" v-show="item.visible" />
+          </transition>
+        </template>
       </div>
     </div>
   </transition>
@@ -95,11 +101,7 @@ export default {
       return this.sidebarPath.length > 0
     },
     sidebarLength () {
-      return this.sidebarAnimation ? this.sidebarPath.length - 1 : this.sidebarPath.length
-    },
-    translateX () {
-      const translateX = this.sidebarLength > 0 ? (this.sidebarLength) * -100 : 0
-      return this.hasSubmenu ? { transform: `translateX(${translateX}%)` } : {}
+      return this.sidebarPath.length
     }
   }
 }
@@ -153,8 +155,4 @@ $z-index-modal: map-get($z-index, modal);
   right: 0;
 }
 
-.sidebar .submenu-wrapper {
-  position: relative;
-  transition: transform .5s;
-}
 </style>

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <transition :name="direction === 'right' ? 'slide-left' : direction === 'left' ? 'slide-right' : null">
     <div
-      class="sidebar t-max-w-full t-fixed t-scrolling-touch t-bg-white"
+      class="sidebar t-max-w-90pc t-fixed t-scrolling-touch t-bg-white"
       :class="[direction === 'left' ? 'left-sidebar' : direction === 'right' ? 'right-sidebar' : null, { 'wide': wide }]"
       data-test-id="Sidebar"
       ref="sidebar"

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -10,7 +10,7 @@
       <div class="submenu-wrapper t-relative">
         <component :is="component" @close="$emit('close')" @reload="getComponent" v-show="!hasSubmenu" :key="'sidebar-home'" />
         <template v-for="(item, i) in sidebarPath">
-          <submenu :key="'submenu-' + i" :index="i" :async-component="item.component" />
+          <submenu :key="'submenu-' + i" :index="i" :async-component="item.component" v-show="i === sidebarLastIndex" />
         </template>
       </div>
     </div>
@@ -97,6 +97,9 @@ export default {
     },
     sidebarLength () {
       return this.sidebarPath.length
+    },
+    sidebarLastIndex () {
+      return this.sidebarLength - 1
     }
   }
 }

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -131,6 +131,14 @@ $z-index-modal: map-get($z-index, modal);
   max-height: 100vh;
   overflow: auto;
 
+  &.slide-left-enter-active .sidebar-menu .header,
+  &.slide-left-leave-active .sidebar-menu .header,
+  &.slide-right-enter-active .sidebar-menu .header,
+  &.slide-right-leave-active .sidebar-menu .header {
+    /** This prevents flickering of the header during the animation */
+    max-width: 100% !important;
+  }
+
   &, .sidebar-menu .header {
     z-index: $z-index-modal;
     width: 460px;

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="sidebar-menu t-w-full t-flex t-flex-col" ref="container">
-    <div class="t-h-60px t-flex-fix t-px-2 t-bg-white t-border-b t-border-base-lighter t-flex t-items-center">
+    <div class="header t-fixed t-z-1 t-w-full t-max-w-90pc t-h-60px t-flex-fix t-px-2 t-bg-white t-border-b t-border-base-lighter t-flex t-items-center">
       <slot name="top" />
       <h2 class="t-pl-2 t-text-lg t-text-base-dark" v-if="title" v-text="title" />
       <slot name="top-after-title" />
       <div class="t-flex-expand" v-if="useExpanderInTitle" />
       <top-button data-test-id="closeButton" :icon="closeIcon" text="Close" :tab-index="1" @click.native="closeMenu" class="t-text-base" />
     </div>
+    <div class="spacer t-h-60px" />
     <div @click="closeAfterClick" class="sidebar-content t-p-4">
       <slot />
     </div>
@@ -15,7 +16,6 @@
 </template>
 
 <script>
-import { mapState, mapGetters } from 'vuex'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import onEscapePress from '@vue-storefront/core/mixins/onEscapePress'
 

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
@@ -5,7 +5,7 @@
       <h2 class="t-pl-2 t-text-lg t-text-base-dark" v-if="title" v-text="title" />
       <slot name="top-after-title" />
       <div class="t-flex-expand" v-if="useExpanderInTitle" />
-      <top-button data-test-id="closeButton" icon="close" text="Close" :tab-index="1" @click.native="closeMenu" class="t-text-base" />
+      <top-button data-test-id="closeButton" :icon="closeIcon" text="Close" :tab-index="1" @click.native="closeMenu" class="t-text-base" />
     </div>
     <div @click="closeAfterClick" class="sidebar-content t-p-4">
       <slot />
@@ -31,6 +31,10 @@ export default {
     useExpanderInTitle: {
       type: Boolean,
       default: true
+    },
+    closeIcon: {
+      type: String,
+      default: 'close'
     },
     closeOnClick: {
       type: Boolean,

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Submenu.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Submenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <sidebar class="t-absolute t-top-0 t-w-full" :style="{ left: `${(index + 1) * 100}%` }" :title="sidebar.title" :close-on-click="false">
+  <sidebar class="t-absolute t-top-0" :title="sidebar.title" :close-icon="sidebar.closeIcon" :close-on-click="false">
     <template v-slot:top>
       <top-button icon="keyboard_arrow_left" text="Back" :tab-index="1" @click.native="close" class="t-text-base" />
     </template>

--- a/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <sidebar :title="$t('Filter')" :close-on-click="false">
+  <sidebar :title="$t('Filter')" :close-icon="closeIcon" :close-on-click="false">
     <template v-slot:top-after-title>
       <button-component v-if="hasActiveFilters" type="transparent" size="sm" icon="delete_sweep" :icon-only="true" @click="resetAllFilters">
         {{ $t('Clear filters') }}
@@ -92,6 +92,9 @@ export default {
         allAvailableFilters.filter(f => parentsOfNestedFilters.includes(f.attributeKey)),
         allAvailableFilters.filter(f => !parentsOfNestedFilters.includes(f.attributeKey))
       ].map(this.sortOptions)
+    },
+    closeIcon () {
+      return this.hasActiveFilters ? 'check' : undefined
     }
   },
   methods: {

--- a/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
@@ -140,7 +140,8 @@ export default {
     },
     openSubmenuFilter (filter) {
       if (filter.submenu) {
-        this.$store.dispatch('ui/addSidebarPath', { component: AsyncFilter, title: filter.attributeLabel, props: filter })
+        const sidebarProps = { title: filter.attributeLabel, closeIcon: this.closeIcon }
+        this.$store.dispatch('ui/addSidebarPath', { component: AsyncFilter, ...sidebarProps, props: filter })
       }
     }
   }

--- a/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
@@ -141,8 +141,14 @@ export default {
     openSubmenuFilter (filter) {
       if (filter.submenu) {
         const sidebarProps = { title: filter.attributeLabel, closeIcon: this.closeIcon }
-        this.$store.dispatch('ui/addSidebarPath', { component: AsyncFilter, ...sidebarProps, props: filter })
+        const sidebar = { component: AsyncFilter, ...sidebarProps, props: filter }
+        this.$store.dispatch('ui/addSidebarPath', { sidebar })
       }
+    }
+  },
+  watch: {
+    closeIcon (closeIcon) {
+      this.$store.dispatch('ui/mapSidebarPathItems', sidebar => Object.assign(sidebar, { closeIcon }))
     }
   }
 }

--- a/src/themes/icmaa-imp/components/core/blocks/Header/ButtonAccount.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Header/ButtonAccount.vue
@@ -22,7 +22,7 @@ export default {
       if (!this.isLoggedIn) {
         this.$bus.$emit('modal-toggle', 'modal-signup')
       } else {
-        this.$store.dispatch('ui/setUserSidebar', true)
+        this.$store.dispatch('ui/setUserSidebar', { active: true, appear: false })
       }
     }
   }

--- a/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -79,7 +79,7 @@ export default {
       if (!this.isLoggedIn) {
         this.$bus.$emit('modal-toggle', 'modal-signup')
       } else {
-        this.$store.dispatch('ui/setUserSidebar', true)
+        this.$store.dispatch('ui/setUserSidebar', { active: true })
       }
     },
     showLanguageSwitcher () {

--- a/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -10,8 +10,8 @@
     </template>
     <template v-slot:footer>
       <div class="t-flex-expand t-bg-base-lightest t-p-4" data-test-id="SidebarMenuFooter">
-        <div class="t-flex t-items-center t-w-full">
-          <div class="t-flex t-items-center t-w-full" @click="closeMenu">
+        <div class="t-flex t-items-center t-flex-wrap t-w-full">
+          <div class="t-flex t-items-center" @click="closeMenu">
             <template v-for="(link, index) in metaNavigation">
               <router-link :to="localizedRoute(link.route)" :title="link.name | htmlDecode" class="t-flex t-flex-fit t-mr-6 t-text-xs t-uppercase t-text-base-tone" :key="index" v-if="link.isRoute === true">
                 {{ link.name }}
@@ -63,7 +63,7 @@ export default {
     metaNavigation () {
       return this.getJsonBlockByIdentifier('navigation-meta').map(link =>
         Object.assign(link, { isRoute: (typeof link.route === 'object' || link.route.startsWith('/')) })
-      )
+      ).slice(0, 3)
     },
     country: () => currentStoreView().i18n.defaultCountry,
     loginButtonText () {

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -26,8 +26,9 @@
               </dropdown>
             </div>
             <div class="t-w-1/2 lg:t-w-3/4 t-px-1 lg:t-px-2 t-flex t-items-center">
-              <button-component style="second" align="stretch" icon="filter_list" @click.native="openFilters" class="t-w-full lg:t-w-auto" data-test-id="ButtonFilter">
+              <button-component style="second" align="stretch" :icon="activeFilterCount > 0 ? 'check' : 'filter_list'" @click.native="openFilters" class="t-w-full lg:t-w-auto" data-test-id="ButtonFilter">
                 {{ $t('Filters') }}
+                <span v-if="activeFilterCount > 0" v-text="`(${activeFilterCount})`" class="t-flex-grow t-text-left t-pl-2" />
               </button-component>
               <presets class="t-hidden lg:t-flex t-items-center t-ml-2" />
             </div>
@@ -172,6 +173,7 @@ export default {
       getCategoryProducts: 'category-next/getCategoryProducts',
       getCurrentCategory: 'category-next/getCurrentCategory',
       getCategoryProductsTotal: 'category-next/getCategoryProductsTotal',
+      getCurrentFilters: 'category-next/getCurrentFilters',
       getProductsStats: 'category-next/getCategorySearchProductsStats',
       isInTicketWhitelist: 'category-next/isCurrentCategoryInTicketWhitelist',
       contentHeader: 'icmaaCategoryExtras/getContentHeaderByCurrentCategory'
@@ -188,6 +190,9 @@ export default {
     moreProductsInSearchResults () {
       const { perPage, start, total } = this.getProductsStats
       return (start + perPage < total)
+    },
+    activeFilterCount () {
+      return Object.keys(this.getCurrentFilters).length
     }
   },
   async asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data - and it's always executed before parent component methods

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -28,7 +28,7 @@
             <div class="t-w-1/2 lg:t-w-3/4 t-px-1 lg:t-px-2 t-flex t-items-center">
               <button-component style="second" align="stretch" :icon="activeFilterCount > 0 ? 'check' : 'filter_list'" @click.native="openFilters" class="t-w-full lg:t-w-auto" data-test-id="ButtonFilter">
                 {{ $t('Filters') }}
-                <span v-if="activeFilterCount > 0" v-text="`(${activeFilterCount})`" class="t-flex-grow t-text-left t-pl-2" />
+                <span v-if="activeFilterCount > 0" v-text="`(${activeFilterCount})`" class="t-flex-grow t-text-left t-pl-2 t-opacity-75" />
               </button-component>
               <presets class="t-hidden lg:t-flex t-items-center t-ml-2" />
             </div>

--- a/src/themes/icmaa-imp/store/ui.ts
+++ b/src/themes/icmaa-imp/store/ui.ts
@@ -9,7 +9,6 @@ export const uiStore = {
   state: {
     viewport: false,
     sidebarPath: [],
-    sidebarAnimation: false,
     overlay: false,
     loader: false,
     authElem: 'login',
@@ -48,33 +47,10 @@ export const uiStore = {
       state.overlay = status
     },
     addSidebarPath (state, payload) {
-      let sidebars = state.sidebarPath.map(s => Object.assign(s, { visible: false, animation: 'slide-right' }))
-      sidebars.push(Object.assign({ appear: true }, payload, { visible: true, animation: 'slide-left' }))
-      Vue.set(state, 'sidebarPath', sidebars)
+      state.sidebarPath.push(payload)
     },
     removeSidebarPath (state) {
-      const animationTime = 250
-      state.sidebarAnimation = true
-
-      // Make last item invisible
-      const lastIndex = state.sidebarPath.length - 1
-      const last = Object.assign(state.sidebarPath[lastIndex], { visible: false })
-      Vue.set(state.sidebarPath, lastIndex, last)
-
-      // Make item before last item visible
-      const previousIndex = lastIndex - 1
-      if (previousIndex >= 0) {
-        const previous = Object.assign(state.sidebarPath[previousIndex], { visible: true })
-        Vue.set(state.sidebarPath, previousIndex, previous)
-        setTimeout(() => {
-          Vue.set(state.sidebarPath, previousIndex, Object.assign(previous, { animation: 'slide-left' }))
-        }, animationTime)
-      }
-
-      setTimeout(() => {
-        state.sidebarAnimation = false
-        Vue.delete(state.sidebarPath, lastIndex)
-      }, animationTime)
+      Vue.delete(state.sidebarPath, state.sidebarPath.length - 1)
     },
     setOverlay (state, action: boolean) {
       state.overlay = action === true
@@ -146,7 +122,6 @@ export const uiStore = {
   },
   getters: {
     getViewport: state => state.viewport,
-    getSidebarPath: state => state.sidebarPath,
-    getSidebarAnimation: state => state.sidebarAnimation
+    getSidebarPath: state => state.sidebarPath
   }
 }

--- a/src/themes/icmaa-imp/store/ui.ts
+++ b/src/themes/icmaa-imp/store/ui.ts
@@ -36,6 +36,7 @@ export const uiStore = {
       state.addtocart = false
       state.categoryfilter = false
       state.overlay = false
+      state.sidebarPath = []
     },
     setCheckoutMode (state, action: boolean) {
       state.checkoutMode = action === true
@@ -47,14 +48,33 @@ export const uiStore = {
       state.overlay = status
     },
     addSidebarPath (state, payload) {
-      state.sidebarPath.push(payload)
+      let sidebars = state.sidebarPath.map(s => Object.assign(s, { visible: false, animation: 'slide-right' }))
+      sidebars.push(Object.assign({ appear: true }, payload, { visible: true, animation: 'slide-left' }))
+      Vue.set(state, 'sidebarPath', sidebars)
     },
     removeSidebarPath (state) {
+      const animationTime = 250
       state.sidebarAnimation = true
+
+      // Make last item invisible
+      const lastIndex = state.sidebarPath.length - 1
+      const last = Object.assign(state.sidebarPath[lastIndex], { visible: false })
+      Vue.set(state.sidebarPath, lastIndex, last)
+
+      // Make item before last item visible
+      const previousIndex = lastIndex - 1
+      if (previousIndex >= 0) {
+        const previous = Object.assign(state.sidebarPath[previousIndex], { visible: true })
+        Vue.set(state.sidebarPath, previousIndex, previous)
+        setTimeout(() => {
+          Vue.set(state.sidebarPath, previousIndex, Object.assign(previous, { animation: 'slide-left' }))
+        }, animationTime)
+      }
+
       setTimeout(() => {
         state.sidebarAnimation = false
-        Vue.delete(state.sidebarPath, state.sidebarPath.length - 1)
-      }, 500)
+        Vue.delete(state.sidebarPath, lastIndex)
+      }, animationTime)
     },
     setOverlay (state, action: boolean) {
       state.overlay = action === true
@@ -89,33 +109,33 @@ export const uiStore = {
       commit('setCloseAll')
       clearAllBodyScrollLocks()
     },
-    setSidebar ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'sidebar', status)
+    setSidebar ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'sidebar', active)
     },
-    setUserSidebar ({ commit, dispatch, rootGetters }, status) {
+    setUserSidebar ({ commit, dispatch, rootGetters }, { active, appear = true }) {
       if (!rootGetters['user/isLoggedIn']) {
         return
       }
 
-      commit('toggleSidebar', 'sidebar', status)
-      if (status === true) {
-        dispatch('addSidebarPath', { component: AsyncUserNavigation, title: i18n.t('My account') })
+      commit('toggleSidebar', 'sidebar', active)
+      if (active === true) {
+        dispatch('addSidebarPath', { component: AsyncUserNavigation, title: i18n.t('My account'), appear })
       }
     },
-    setSearchpanel ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'searchpanel', status)
+    setSearchpanel ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'searchpanel', active)
     },
-    setMicrocart ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'microcart', status)
+    setMicrocart ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'microcart', active)
     },
-    setWishlist ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'wishlist', status)
+    setWishlist ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'wishlist', active)
     },
-    setAddtocart ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'addtocart', status)
+    setAddtocart ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'addtocart', active)
     },
-    setCategoryfilter ({ commit }, status: boolean) {
-      commit('toggleSidebar', 'categoryfilter', status)
+    setCategoryfilter ({ commit }, active: boolean) {
+      commit('toggleSidebar', 'categoryfilter', active)
     },
     addSidebarPath ({ commit }, pathItem) {
       commit('addSidebarPath', pathItem)

--- a/src/themes/icmaa-imp/store/ui.ts
+++ b/src/themes/icmaa-imp/store/ui.ts
@@ -46,8 +46,15 @@ export const uiStore = {
       state[property] = status
       state.overlay = status
     },
-    addSidebarPath (state, payload) {
-      state.sidebarPath.push(payload)
+    addSidebarPath (state, { sidebar, index }) {
+      if (index) {
+        Vue.set(state.sidebarPath, index, sidebar)
+      } else {
+        state.sidebarPath.push(sidebar)
+      }
+    },
+    mapSidebarPathItems (state, callback) {
+      Vue.set(state, 'sidebarPath', state.sidebarPath.map(callback))
     },
     removeSidebarPath (state) {
       Vue.delete(state.sidebarPath, state.sidebarPath.length - 1)
@@ -88,14 +95,15 @@ export const uiStore = {
     setSidebar ({ commit }, active: boolean) {
       commit('toggleSidebar', 'sidebar', active)
     },
-    setUserSidebar ({ commit, dispatch, rootGetters }, { active, appear = true }) {
+    setUserSidebar ({ commit, dispatch, rootGetters }, { active }) {
       if (!rootGetters['user/isLoggedIn']) {
         return
       }
 
       commit('toggleSidebar', 'sidebar', active)
       if (active === true) {
-        dispatch('addSidebarPath', { component: AsyncUserNavigation, title: i18n.t('My account'), appear })
+        const sidebar = { component: AsyncUserNavigation, title: i18n.t('My account') }
+        dispatch('addSidebarPath', { sidebar })
       }
     },
     setSearchpanel ({ commit }, active: boolean) {
@@ -113,8 +121,11 @@ export const uiStore = {
     setCategoryfilter ({ commit }, active: boolean) {
       commit('toggleSidebar', 'categoryfilter', active)
     },
-    addSidebarPath ({ commit }, pathItem) {
-      commit('addSidebarPath', pathItem)
+    addSidebarPath ({ commit }, { sidebar, index }) {
+      commit('addSidebarPath', { sidebar, index })
+    },
+    mapSidebarPathItems ({ commit }, callback) {
+      commit('mapSidebarPathItems', callback)
     },
     removeLastSidebarPath ({ commit }) {
       commit('removeSidebarPath')

--- a/src/themes/icmaa-imp/tailwind.js
+++ b/src/themes/icmaa-imp/tailwind.js
@@ -52,7 +52,8 @@ module.exports = {
         'screen-50': '50vw',
         'screen-75': '75vw',
         'screen-100': '100vw',
-        '1/2': '50%'
+        '1/2': '50%',
+        '90pc': '90%'
       },
       fontSize: {
         'reset': '0',

--- a/src/themes/icmaa-imp/test/e2e/integration/Catalog/filter.spec.ts
+++ b/src/themes/icmaa-imp/test/e2e/integration/Catalog/filter.spec.ts
@@ -6,8 +6,11 @@ describe('Filter', () => {
       const productsTotalNumber = parseInt(element.text())
 
       cy.openFilterSidebar()
-      cy.get('@sidebar').find('[data-attribute-key="department"] button')
-        .clickRandomElement()
+      cy.get('@sidebar')
+        .find('[data-attribute-key="department"] button')
+        .random()
+        .scrollIntoView({ offset: { top: -200, left: 0 }, duration: 1000 })
+        .click({ force: true })
 
       cy.url().should('include', `?department=`)
 


### PR DESCRIPTION
* Show check-icons if a filter is selected
* Show content behind sidebar in mobile view
* Fix header inside the sidebar
* Remove animation for submenus as they complicate the structure and don't bring benefits

<img width="355" alt="Screenshot 2020-05-06 10 35 00" src="https://user-images.githubusercontent.com/6112764/81155477-48060d80-8f85-11ea-9a06-b2b5c1742f22.png">
<img width="355" alt="Screenshot 2020-05-06 10 35 08" src="https://user-images.githubusercontent.com/6112764/81155486-49cfd100-8f85-11ea-83d0-de621e378fcd.png">
