### PR TITLE
#200281 Bugfix for wrong router names of `icmaa-newsletter`

### DIFF
--- a/src/modules/icmaa-newsletter/routes.ts
+++ b/src/modules/icmaa-newsletter/routes.ts
@@ -1,8 +1,6 @@
-const NewsletterComponent = () => import(/* webpackChunkName: "vsf-icmaa-newsletter-landingpage" */ 'icmaa-newsletter/pages/Newsletter.vue')
 const NewsletterVoucher = () => import(/* webpackChunkName: "vsf-icmaa-newsletter-newsletter-voucher" */ 'icmaa-newsletter/pages/NewsletterVoucher.vue')
 
 export default [
-  { name: 'newsletter', path: '/:identifier', component: NewsletterComponent },
-  { name: 'newsletter-voucher', path: '/newsletter/voucher', component: NewsletterVoucher },
-  { name: 'newsletter-birthday-voucher', path: '/newsletter/birthday-voucher', component: NewsletterVoucher, props: { isBirthday: true } }
+  { name: 'icmaa-newsletter-voucher', path: '/newsletter/voucher', component: NewsletterVoucher },
+  { name: 'icmaa-newsletter-birthday-voucher', path: '/newsletter/birthday-voucher', component: NewsletterVoucher, props: { isBirthday: true } }
 ]

--- a/src/themes/icmaa-imp/router/icmaa-cms/router.ts
+++ b/src/themes/icmaa-imp/router/icmaa-cms/router.ts
@@ -4,6 +4,7 @@ const ServiceRTEComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-pag
 const ServiceSizeComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-service-size" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/ServiceSize.vue')
 const ServiceContactComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-service-contact" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/ServiceContact.vue')
 const ServiceWiderrufComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-service-widerruf" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/ServiceWiderruf.vue')
+const NewsletterComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-newsletter-landingpage" */ 'icmaa-newsletter/pages/Newsletter.vue')
 const AffiliateComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-affiliate" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/Affiliate.vue')
 const TicketsComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-tickets" */ 'theme/pages/Tickets.vue')
 const FestivalComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-festival" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/Festival.vue')
@@ -16,6 +17,7 @@ export const routes: any = [
   { name: 'service-size', path: '/:identifier', component: ServiceSizeComponent },
   { name: 'service-contact', path: '/:identifier', component: ServiceContactComponent },
   { name: 'service-widerruf', path: '/:identifier', component: ServiceWiderrufComponent },
+  { name: 'newsletter', path: '/:identifier', component: NewsletterComponent },
   { name: 'affiliate', path: '/:identifier', component: AffiliateComponent },
   { name: 'tickets', path: '/:identifier', component: TicketsComponent },
   { name: 'festival', path: '/:identifier', component: FestivalComponent },


### PR DESCRIPTION
* Put back the `/newsletter` landing-page to the theme as it anyway is a theme page and not functional bound to the `icmaa-newsletter` module
* This caused that all routes are overwritten by the `/:identifier` path and therefore are not accessible