### PR TITLE
#200709 Bugfix for `customercluster` related content

### DIFF
--- a/src/modules/icmaa-category/store/actions.ts
+++ b/src/modules/icmaa-category/store/actions.ts
@@ -61,14 +61,21 @@ const actions: ActionTree<CategoryState, RootState> = {
       })
     }
 
+    let sortArray: string[] = typeof sort === 'string' ? [sort] : sort
+
     if (cluster) {
       cluster = parseInt(cluster)
       query.applyFilter({ key: 'customercluster', value: { or: [cluster] } })
       query.applyFilter({ key: 'customercluster', value: { or: null } })
-      sort = [sort as string, 'customercluster:desc']
+      sortArray.push('customercluster:desc')
     }
 
-    return dispatch('product/findProducts', { query, size, sort }, { root: true }).then(products => {
+    sortArray.forEach(sort => {
+      const [ field, options ] = sort.split(':')
+      query.applySort({ field, options })
+    })
+
+    return dispatch('product/findProducts', { query, size }, { root: true }).then(products => {
       const payload = { parent: categoryId, list: products.items, cluster, filterHash }
       commit(types.ICMAA_CATEGORY_LIST_ADD_PRODUCT, payload)
       return payload

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -140,7 +140,8 @@ const actions: ActionTree<UserState, RootState> = {
       })
   },
   setCluster ({ commit }, cluster) {
-    if (!isEmpty(cluster) || cluster === false) {
+    // Don't set cluster for `always visible`/`0` as `customercluster` value
+    if ((!isEmpty(cluster) || cluster === false) && cluster !== '0' && cluster !== 0) {
       commit(types.USER_ADD_SESSION_DATA, { key: 'cluster', value: cluster })
     }
   },


### PR DESCRIPTION
* Don't set cluster for `always visible`/`0` as `customercluster` value
* Bugfix for sorting when clusters are used for products-list on homepage