### PR TITLE
Add localstorage quota to icmaa modules to enable garbage collection

### DIFF
--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -176,7 +176,7 @@ export function initializeSyncTaskStorage () {
   const storeView = currentStoreView()
   const dbNamePrefix = storeView.storeCode ? storeView.storeCode + '-' : ''
 
-  StorageManager.init('syncTasks')
+  StorageManager.init('syncTasks', undefined, config.server.elasticCacheQuota)
 }
 
 export function registerSyncTaskProcessor () {

--- a/src/modules/icmaa-advice/index.ts
+++ b/src/modules/icmaa-advice/index.ts
@@ -1,10 +1,11 @@
+import config from 'config'
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 import { AdviceStore, adviceStateKey } from './store'
 
 export const KEY = 'icmaa-advice'
-export const cacheStorage = StorageManager.init(KEY)
+export const cacheStorage = StorageManager.init(KEY, undefined, 512)
 
 export const IcmaaAdviceModule: StorefrontModule = function ({ store }) {
   store.registerModule(adviceStateKey, AdviceStore)

--- a/src/modules/icmaa-category-extras/index.ts
+++ b/src/modules/icmaa-category-extras/index.ts
@@ -1,9 +1,10 @@
+import config from 'config'
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 import { CategoryExtrasStore, categoryExtrasStateKey, categoryExtrasStorageKey } from './store'
 
-export const cacheStorage = StorageManager.init(categoryExtrasStorageKey)
+export const cacheStorage = StorageManager.init(categoryExtrasStorageKey, undefined, 2048)
 
 export const IcmaaCategoryExtrasModule: StorefrontModule = function ({ store }) {
   store.registerModule(categoryExtrasStateKey, CategoryExtrasStore)

--- a/src/modules/icmaa-cms/helpers/genericStateModule.ts
+++ b/src/modules/icmaa-cms/helpers/genericStateModule.ts
@@ -22,7 +22,7 @@ const registerGenericCmsStateModule = (stateKey: string, documentType: string, e
   }
 
   const Module: StorefrontModule = function ({ store }) {
-    StorageManager.init(namespace)
+    StorageManager.init(namespace, undefined, 128)
     store.registerModule(ccNamespace, createGenericStore(stateKey, namespace, documentType, extendStore))
 
     Logger.debug('Loaded generic cms state module:', 'icmaa-cms', ccNamespace)()

--- a/src/modules/icmaa-cms/index.ts
+++ b/src/modules/icmaa-cms/index.ts
@@ -1,3 +1,4 @@
+import config from 'config'
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { setupMultistoreRoutes } from '@vue-storefront/core/lib/multistore'
@@ -10,7 +11,7 @@ import { PageStore, cmsPageStateKey } from './store/page'
 import moduleRoutes from './routes'
 
 export const KEY = 'icmaa-cms'
-export const cacheStorage = StorageManager.init(KEY, false, 5120)
+export const cacheStorage = StorageManager.init(KEY, undefined, config.server.elasticCacheQuota)
 
 export const IcmaaCmsModule: StorefrontModule = function ({ store, appConfig, router }) {
   store.registerModule(defaultStateKey, DefaultStore)

--- a/src/modules/icmaa-competitions/index.ts
+++ b/src/modules/icmaa-competitions/index.ts
@@ -5,7 +5,7 @@ import { setupMultistoreRoutes } from '@vue-storefront/core/lib/multistore'
 import { CompetitionsStore, competitionsStateKey, competitionsStorageKey } from './store'
 import moduleRoutes from './routes'
 
-export const cacheStorage = StorageManager.init(competitionsStorageKey)
+export const cacheStorage = StorageManager.init(competitionsStorageKey, undefined, 128)
 
 export const IcmaaCompetitionsModule: StorefrontModule = async function ({ store, appConfig, router }) {
   store.registerModule(competitionsStateKey, CompetitionsStore)

--- a/src/modules/icmaa-config/index.ts
+++ b/src/modules/icmaa-config/index.ts
@@ -12,7 +12,7 @@ import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 export const cacheStorageKey = 'icmaa-config'
-export const cacheStorage = StorageManager.init(cacheStorageKey, false)
+export const cacheStorage = StorageManager.init(cacheStorageKey, false, config.server.elasticCacheQuota)
 
 export const IcmaaExtendedConfigModule: StorefrontModule = function ({ store }) {
   if (config.storeViews.multistore === true) {

--- a/src/modules/icmaa-forms/index.ts
+++ b/src/modules/icmaa-forms/index.ts
@@ -4,7 +4,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { FormsStore, formsStateKey, formsStorageKey } from './store'
 
 export const KEY = formsStorageKey
-export const cacheStorage = StorageManager.init(formsStorageKey)
+export const cacheStorage = StorageManager.init(formsStorageKey, undefined, 128)
 
 export const IcmaaFormsModule: StorefrontModule = function ({ store }) {
   store.registerModule(formsStateKey, FormsStore)

--- a/src/modules/icmaa-recommendations/index.ts
+++ b/src/modules/icmaa-recommendations/index.ts
@@ -3,7 +3,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 import { RecommendationsStore, storageKey, stateKey } from './store'
 
-export const cacheStorage = StorageManager.init(storageKey)
+export const cacheStorage = StorageManager.init(storageKey, undefined, 512)
 
 export const IcmaaRecommendationsModule: StorefrontModule = function ({ store }) {
   store.registerModule(stateKey, RecommendationsStore)

--- a/src/modules/icmaa-spotify/index.ts
+++ b/src/modules/icmaa-spotify/index.ts
@@ -5,7 +5,7 @@ import { SpotifyStore } from './store'
 
 export const KEY = 'icmaa-spotify'
 export const storageKey = 'spotify'
-export const cacheStorage = StorageManager.init(KEY)
+export const cacheStorage = StorageManager.init(KEY, undefined, 128)
 
 export const IcmaaSpotifyModule: StorefrontModule = function ({ store }) {
   store.registerModule('icmaaSpotify', SpotifyStore)

--- a/src/modules/icmaa-teaser/index.ts
+++ b/src/modules/icmaa-teaser/index.ts
@@ -6,7 +6,7 @@ import { TeaserStore, teaserStateKey } from './store'
 import moduleRoutes from './routes'
 
 export const KEY = 'icmaa-teaser'
-export const cacheStorage = StorageManager.init(KEY)
+export const cacheStorage = StorageManager.init(KEY, undefined, 1024)
 
 export const IcmaaTeaserModule: StorefrontModule = function ({ store, appConfig, router }) {
   store.registerModule(teaserStateKey, TeaserStore)

--- a/src/modules/icmaa-twitter/index.ts
+++ b/src/modules/icmaa-twitter/index.ts
@@ -4,7 +4,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { TwitterStore } from './store'
 
 export const KEY = 'icmaa-twitter'
-export const cacheStorage = StorageManager.init(KEY)
+export const cacheStorage = StorageManager.init(KEY, undefined, 512)
 
 export const IcmaaTwitterModule: StorefrontModule = function ({ store }) {
   store.registerModule('icmaaTwitter', TwitterStore)


### PR DESCRIPTION
* If we don't add a quota value, the localstorage could overflow and drop exceptions in browser - this should prevent this