### PR TITLE
Release 2020-06-05

### DIFF
--- a/src/modules/icmaa-cms/components/Wrapper.vue
+++ b/src/modules/icmaa-cms/components/Wrapper.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-
+import config from 'config'
 import omit from 'lodash-es/omit'
 import mapKeys from 'lodash-es/mapKeys'
 import mapValues from 'lodash-es/mapValues'
@@ -26,6 +26,14 @@ export default {
     }
   },
   computed: {
+    hideTeaser () {
+      const { urlParamWhitelist } = config.icmaa_teaser
+      const query = Object.keys(this.$route.query)
+      if (query.length > 0 && query.some(el => urlParamWhitelist.includes(el))) {
+        return false
+      }
+      return query.length > 0
+    },
     componentsMap () {
       return {
         'component_teaser': {
@@ -65,6 +73,7 @@ export default {
     componentsReady () {
       return this.components
         .filter(c => Object.keys(this.componentsMap).includes(c.component))
+        .filter(c => this.hideTeaser ? c.component !== 'component_teaser' : true)
         .map(c => {
           const componentsMap = this.componentsMap[c.component]
           const { component, propsTypes, propsDefaults, cssClass, padding } = componentsMap

--- a/src/modules/icmaa-recommendations/helpers/Rules.ts
+++ b/src/modules/icmaa-recommendations/helpers/Rules.ts
@@ -213,7 +213,7 @@ class Rules {
    * @returns {this}
    */
   protected filterAttributeNotNull ({ key, value, isOr }: FilterOptions): this {
-    this.filterAttributeIsNullAndIsNotNull({ key, value, isOr }, false)
+    this.filterAttributeIsNullAndIsNotNull({ key, value, isOr }, true)
     return this
   }
 
@@ -221,7 +221,7 @@ class Rules {
    * @returns {this}
    */
   protected filterAttributeIsNull ({ key, value, isOr }: FilterOptions): this {
-    this.filterAttributeIsNullAndIsNotNull({ key, value, isOr }, true)
+    this.filterAttributeIsNullAndIsNotNull({ key, value, isOr }, false)
     return this
   }
 

--- a/src/themes/icmaa-imp/resource/i18n/it-IT.csv
+++ b/src/themes/icmaa-imp/resource/i18n/it-IT.csv
@@ -122,7 +122,7 @@
 "German","Tedesco"
 "Germany","Germania"
 "Get inspired","Lasciati ispirare"
-"Get the Impericon Newsletter & and get yourself a {voucher_value} gift.","Ricevi la Newsletter LiveYourMusic & e ricevi un regalo di {voucher_value}."
+"Get the Impericon Newsletter & and get yourself a {voucher_value} gift.","Ricevi la Newsletter Impericon & e ricevi un regalo di {voucher_value}."
 "Get your {voucher_value} Voucher","Ottieni il tuo coupon da {voucher_value}"
 "Give a feedback","Dai un feedback"
 "Go review the order","Controlla l'ordine"

--- a/src/themes/icmaa-imp/test/e2e/integration/Catalog/teaser.spec.ts
+++ b/src/themes/icmaa-imp/test/e2e/integration/Catalog/teaser.spec.ts
@@ -1,0 +1,12 @@
+describe('Teaser', () => {
+  it('should be visible on category page', () => {
+    cy.visit('/sales.html')
+    cy.getByTestId('Teaser').should('be.visible')
+  })
+  it('should be toggled on category page when GET parameter filter is set', () => {
+    cy.visit('/sales.html?gender=9')
+    cy.getByTestId('Teaser').should('be.not.visible')
+    cy.visit('/sales.html?utm_source=CUSTOMSOURCE')
+    cy.getByTestId('Teaser').should('be.visible')
+  })
+})

--- a/src/themes/icmaa-imp/test/e2e/integration/Customer/resetPassword.spec.ts
+++ b/src/themes/icmaa-imp/test/e2e/integration/Customer/resetPassword.spec.ts
@@ -1,0 +1,14 @@
+describe('Resetpassword page', () => {
+  it('Show forgot-password modal', () => {
+    cy.visit('/customer/account/resetpassword')
+    cy.get('[data-test-id=Modal]').should('be.visible')
+    cy.get('@storeCode').then((storeCode) => {
+      cy.location('pathname').should('eq', `/${storeCode}/`)
+    })
+  })
+  it('Dont show forgot-password modal', () => {
+    cy.visit('/customer/account/resetpassword?token=testtoken&email=testemail')
+    cy.get('[data-test-id=Modal]').should('not.be.visible')
+    cy.location('pathname').should('include', '/customer/account/resetpassword')
+  })
+})


### PR DESCRIPTION
* #201742 Added E2E test for reset-password page (#343)
* #201739 Hide teaser on category-page when GET params are set (#349)
* #201936 Bugfix for transposed booleans in `icmaa-recommendations` module (#348)
* #200073 Change `liveyourmusic` to `impericon` (#350)