### PR TITLE
#199412 Enable meta-attribute support

### DIFF
--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -14,7 +14,9 @@ const i18n = new VueI18n({
   fallbackLocale: 'en-US',
   messages: config.i18n.bundleAllStoreviewLanguages ? require('./resource/i18n/multistoreLanguages.json') : {
     'en-US': require('./resource/i18n/en-US.json')
-  }
+  },
+  silentTranslationWarn: true,
+  silentFallbackWarn: true
 })
 
 function setI18nLanguage (lang: string): string {

--- a/core/lib/search/adapter/api-search-query/searchAdapter.ts
+++ b/core/lib/search/adapter/api-search-query/searchAdapter.ts
@@ -117,6 +117,7 @@ export class SearchAdapter {
         start: start,
         perPage: size,
         aggregations: resp.aggregations,
+        attributeMetadata: resp.attribute_metadata,
         suggestions: resp.suggest
       }
     } else {

--- a/core/modules/catalog/helpers/associatedProducts/index.ts
+++ b/core/modules/catalog/helpers/associatedProducts/index.ts
@@ -1,7 +1,9 @@
 import setGroupedProduct from './setGroupedProduct'
 import setBundleProducts from './setBundleProducts'
+import setAttributesMetaFromProducts from './setAttributesMetaFromProducts'
 
 export {
   setGroupedProduct,
-  setBundleProducts
+  setBundleProducts,
+  setAttributesMetaFromProducts
 }

--- a/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
@@ -1,8 +1,11 @@
+import config from 'config'
 import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 /**
  * Set associated attributes by meta data of product links
  */
 export default async function setAttributesMetaFromProducts (context: any, products: Product[]) {
-  context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+  if (config.entities.attribute.loadByAttributeMetadata) {
+    context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+  }
 }

--- a/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
@@ -1,0 +1,8 @@
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
+
+/**
+ * Set associated attributes by meta data of product links
+ */
+export default async function setAttributesMetaFromProducts (context: any, products: Product[]) {
+  context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+}

--- a/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
@@ -1,8 +1,9 @@
-import Product from '@vue-storefront/core/modules/catalog/types/Product';
-import { isBundleProduct } from './..';
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
+import { isBundleProduct } from './..'
 import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import { catalogHooksExecutors } from './../../hooks'
 
 /**
  * This function prepare all product_links for bundle products.
@@ -28,6 +29,8 @@ export default async function setBundleProducts (product: Product, { includeFiel
         separateSelectedVariant: false
       }
     })
+
+    catalogHooksExecutors.afterSetBundleProducts(items)
 
     for (const bundleOption of product.bundle_options) {
       for (const productLink of bundleOption.product_links) {

--- a/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
@@ -1,8 +1,9 @@
-import Product from '@vue-storefront/core/modules/catalog/types/Product';
-import { isGroupedProduct } from './..';
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
+import { isGroupedProduct } from './..'
 import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import { catalogHooksExecutors } from './../../hooks'
 
 /**
  * This function prepare all product_links for grouped products.
@@ -27,6 +28,8 @@ export default async function setGroupedProduct (product: Product, { includeFiel
         separateSelectedVariant: false
       }
     })
+
+    catalogHooksExecutors.afterSetGroupedProduct(items)
 
     for (const productLink of productLinks) {
       const associatedProduct = items.find((associatedProduct) => associatedProduct.sku === productLink.linked_product_sku)

--- a/core/modules/catalog/hooks/index.ts
+++ b/core/modules/catalog/hooks/index.ts
@@ -1,4 +1,4 @@
-import { createMutatorHook } from '@vue-storefront/core/lib/hooks'
+import { createMutatorHook, createListenerHook } from '@vue-storefront/core/lib/hooks'
 import Product from '../types/Product';
 
 const {
@@ -6,12 +6,26 @@ const {
   executor: beforeTaxesCalculatedExecutor
 } = createMutatorHook<Product[], Product[]>()
 
+const {
+  hook: afterSetBundleProductsHook,
+  executor: afterSetBundleProductsExecutor
+} = createListenerHook<Product[]>()
+
+const {
+  hook: afterSetGroupedProductHook,
+  executor: afterSetGroupedProductExecutor
+} = createListenerHook<Product[]>()
+
 const catalogHooksExecutors = {
-  beforeTaxesCalculated: beforeTaxesCalculatedExecutor
+  beforeTaxesCalculated: beforeTaxesCalculatedExecutor,
+  afterSetBundleProducts: afterSetBundleProductsExecutor,
+  afterSetGroupedProduct: afterSetGroupedProductExecutor
 }
 
 const catalogHooks = {
-  beforeTaxesCalculated: beforeTaxesCalculatedHook
+  beforeTaxesCalculated: beforeTaxesCalculatedHook,
+  afterSetBundleProducts: afterSetBundleProductsHook,
+  afterSetGroupedProduct: afterSetGroupedProductHook
 }
 
 export {

--- a/core/modules/catalog/index.ts
+++ b/core/modules/catalog/index.ts
@@ -4,6 +4,8 @@ import { attributeModule } from './store/attribute'
 import { stockModule } from './store/stock'
 import { taxModule } from './store/tax'
 import { categoryModule } from './store/category'
+import { catalogHooks } from './hooks'
+import { setAttributesMetaFromProducts } from './helpers/associatedProducts'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import config from 'config'
@@ -22,6 +24,9 @@ export const CatalogModule: StorefrontModule = async function ({ store, router, 
   store.registerModule('stock', stockModule)
   store.registerModule('tax', taxModule)
   store.registerModule('category', categoryModule)
+
+  catalogHooks.afterSetBundleProducts(products => setAttributesMetaFromProducts(store, products))
+  catalogHooks.afterSetGroupedProduct(products => setAttributesMetaFromProducts(store, products))
 
   // MOD < We do the prefetch on our own routine to improve performance – see `icmaa-catalog/index.ts`.
   // if (!config.entities.attribute.loadByAttributeMetadata) {

--- a/src/modules/icmaa-catalog/store/category/actions/index.ts
+++ b/src/modules/icmaa-catalog/store/category/actions/index.ts
@@ -19,7 +19,8 @@ const actions: ActionTree<CategoryState, RootState> = {
    * Changes:
    * * Add custom default sort and filter
    * * Add custom `includeFields`/`excludeFields` loaded via getter
-   * * Disable child configuration using `setConfigurableProductOptions`
+   * * Disable child configuration using `separateSelectedVariant` – product will still be configured
+   *   but won't overwrite original options like the product image in unisex products
    */
   async loadCategoryProducts ({ commit, getters, dispatch }, { route, category, pageSize = 50 } = {}) {
     const searchCategory = category || getters.getCategoryFrom(route.path) || {}
@@ -40,7 +41,7 @@ const actions: ActionTree<CategoryState, RootState> = {
 
     const { includeFields, excludeFields } = entities.productList
     const sort = searchQuery.sort || `${products.defaultSortBy.attribute}:${products.defaultSortBy.order}`
-    const setConfigurableProductOptions = icmaa_catalog.entities.category.configureChildProductsInCategoryList
+    const separateSelectedVariant = !icmaa_catalog.entities.category.configureChildProductsInCategoryList || false
 
     const { items, perPage, start, total, aggregations, attributeMetadata } = await dispatch('product/findProducts', {
       query: filterQr,
@@ -55,8 +56,7 @@ const actions: ActionTree<CategoryState, RootState> = {
         setProductErrors: false,
         fallbackToDefaultWhenNoAvailable: true,
         assignProductConfiguration: false,
-        separateSelectedVariant: false,
-        setConfigurableProductOptions
+        separateSelectedVariant
       }
     }, { root: true })
     await dispatch('loadAvailableFiltersFrom', {
@@ -74,7 +74,8 @@ const actions: ActionTree<CategoryState, RootState> = {
    * Changes:
    * * Add custom default sort and filter
    * * Add custom `includeFields`/`excludeFields` loaded via getter
-   * * Disable child configuration using `setConfigurableProductOptions`
+   * * Disable child configuration using `separateSelectedVariant` – product will still be configured
+   *   but won't overwrite original options like the product image in unisex products
    */
   async loadMoreCategoryProducts ({ commit, getters, rootState, dispatch }) {
     const { perPage, start, total } = getters.getCategorySearchProductsStats
@@ -93,7 +94,7 @@ const actions: ActionTree<CategoryState, RootState> = {
 
     const { includeFields, excludeFields } = entities.productList
     const sort = searchQuery.sort || `${products.defaultSortBy.attribute}:${products.defaultSortBy.order}`
-    const setConfigurableProductOptions = icmaa_catalog.entities.category.configureChildProductsInCategoryList
+    const separateSelectedVariant = !icmaa_catalog.entities.category.configureChildProductsInCategoryList || false
 
     const searchResult = await dispatch('product/findProducts', {
       query: filterQr,
@@ -109,8 +110,7 @@ const actions: ActionTree<CategoryState, RootState> = {
         setProductErrors: false,
         fallbackToDefaultWhenNoAvailable: true,
         assignProductConfiguration: false,
-        separateSelectedVariant: false,
-        setConfigurableProductOptions
+        separateSelectedVariant
       }
     }, { root: true })
     commit(types.CATEGORY_SET_SEARCH_PRODUCTS_STATS, {


### PR DESCRIPTION
* Update `loadCategoryProducts` & `loadMoreCategoryProducts` in `icmaa-catalog` module
* Disable child configuration in `loadCategoryProducts` and `loadMoreCategoryProducts` using `separateSelectedVariant` and remove custom deprecated `processCategoryProducts` overwrite
* Add `attributeMetadata` to response object of `api-search-query` search adapter to support `loadByAttributeMetadata` feature
* Load attributes data of attribute-meta for bundled and grouped products
* Remove warnings for `vue-i18n`