### PR TITLE
Don't filter by stock when bundled children are loaded

### DIFF
--- a/core/modules/catalog/helpers/associatedProducts/buildQuery.ts
+++ b/core/modules/catalog/helpers/associatedProducts/buildQuery.ts
@@ -9,8 +9,12 @@ export default function buildQuery (skus: string[]): SearchQuery {
   productsQuery = productsQuery
     .applyFilter({ key: 'sku', value: { 'in': skus } })
     .applyFilter({ key: 'status', value: { 'in': [1] } })
-  if (config.products.listOutOfStockProducts === false) {
-    productsQuery = productsQuery.applyFilter({ key: 'stock.is_in_stock', value: { 'eq': true } })
-  }
+
+  // MOD < Don't filter for stock value to have all children
+  // if (config.products.listOutOfStockProducts === false) {
+  //   productsQuery = productsQuery.applyFilter({ key: 'stock.is_in_stock', value: { 'eq': true } })
+  // }
+  // MOD > Don't filter for stock value to have all children
+
   return productsQuery
 }

--- a/src/modules/icmaa-catalog/README.md
+++ b/src/modules/icmaa-catalog/README.md
@@ -67,6 +67,7 @@ We try to overwrite everything needed by extending the Vuex store. But some meth
 
 * We uncommented the original lines in `core/modules/catalog/index.ts` to prevent original preloading and replace it by our, following routing. See comments in the `./index.ts` for more infos
 * We added a custom mutator-event called `afterSelectedVariant` in `core/modules/catalog/helpers/variant/getSelectedVariant.ts` to mutate the `selectedVariant` object. We do this to fix a bug which occurs if you switch between differen configurable options in PDP.
+* We commented out the stock-filter based on `listOutOfStockProducts` config value in `buildQuery` method of `core/modules/catalog/helpers/associatedProducts/buildQuery.ts` – otherwise a sold-out associated product wouldn't be visible in the selection sidebar and might cause an `property of undefined` error
 
 ## Todo
 

--- a/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/BundleSelector.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/BundleSelector.vue
@@ -2,7 +2,7 @@
   <div class="t-w-full">
     <div class="t-bg-alert t-p-4 t-mb-4 t-text-white t-text-sm t-flex" v-if="isChildOutOfStock">
       <material-icon icon="report_problem" class="t-mr-2" />
-      <div class="">
+      <div>
         {{ $t('Sorry, but some required bundle items are currently out-of-stock.') }}
       </div>
     </div>


### PR DESCRIPTION
* We commented out the stock-filter based on `listOutOfStockProducts` config value in `buildQuery` method of `core/modules/catalog/helpers/associatedProducts/buildQuery.ts` – otherwise a sold-out associated product wouldn't be visible in the selection sidebar and might cause an `property of undefined` error