### PR TITLE
#204338 Show out-of-stock message after stock-check on PDP

### DIFF
--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -46,12 +46,12 @@
 
               <div class="t-flex t-flex-wrap">
                 <div v-if="['configurable', 'bundle'].includes(product.type_id) && !isOnesizeProduct" class="t-flex t-flex-grow t-w-full t-mb-4 lg:t-w-3/6 lg:t-mr-4">
-                  <button-component type="select" icon="arrow_forward" data-test-id="AddToCartSize" class="t-w-full" :disabled="isSizeSelectDisabled" @click.native="openAddtocart">
+                  <button-component type="select" icon="arrow_forward" data-test-id="AddToCartSize" class="t-w-full" @click.native="openAddtocart">
                     {{ productOptionsLabel }}
                   </button-component>
                 </div>
-                <button-component :type="isAddToCartDisabled ? 'second' : 'primary'" data-test-id="AddToCart" class="t-flex-grow lg:t-w-2/6 disabled:t-opacity-50 t-relative t-mb-4 t-mr-4" :disabled="isAddToCartDisabled" @click.native="addToCartButtonClick">
-                  {{ isAddToCartDisabled ? $t('Out of stock') : $t('Add to cart') }}
+                <button-component :type="loading || !isAddToCartDisabled ? 'primary' : 'second'" data-test-id="AddToCart" class="t-flex-grow lg:t-w-2/6 disabled:t-opacity-50 t-relative t-mb-4 t-mr-4" :disabled="isAddToCartDisabled" @click.native="addToCartButtonClick">
+                  {{ userHasSelectedVariant && isAddToCartDisabled && !loading ? $t('Out of stock') : $t('Add to cart') }}
                   <loader-background v-if="loading" class="t-bottom-0" height="t-h-1" bar="t-bg-base-lightest t-opacity-25" />
                 </button-component>
                 <add-to-wishlist :product="product" class="t-flex-fix t-mb-4" />
@@ -240,9 +240,6 @@ export default {
       }
 
       return this.$v.$invalid || this.loading || !this.quantity
-    },
-    isSizeSelectDisabled () {
-      return false
     },
     isSingleOptionProduct () {
       return this.product.type_id === 'simple' || this.isOnesizeProduct

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -46,12 +46,12 @@
 
               <div class="t-flex t-flex-wrap">
                 <div v-if="['configurable', 'bundle'].includes(product.type_id) && !isOnesizeProduct" class="t-flex t-flex-grow t-w-full t-mb-4 lg:t-w-3/6 lg:t-mr-4">
-                  <button-component type="select" icon="arrow_forward" data-test-id="AddToCartSize" class="t-w-full" :disabled="isAddToCartDisabled" @click.native="openAddtocart">
+                  <button-component type="select" icon="arrow_forward" data-test-id="AddToCartSize" class="t-w-full" :disabled="isSizeSelectDisabled" @click.native="openAddtocart">
                     {{ productOptionsLabel }}
                   </button-component>
                 </div>
-                <button-component type="primary" data-test-id="AddToCart" class="t-flex-grow lg:t-w-2/6 disabled:t-opacity-75 t-relative t-mb-4 t-mr-4" :disabled="isAddToCartDisabled" @click.native="addToCartButtonClick">
-                  {{ $t('Add to cart') }}
+                <button-component :type="isAddToCartDisabled ? 'second' : 'primary'" data-test-id="AddToCart" class="t-flex-grow lg:t-w-2/6 disabled:t-opacity-50 t-relative t-mb-4 t-mr-4" :disabled="isAddToCartDisabled" @click.native="addToCartButtonClick">
+                  {{ isAddToCartDisabled ? $t('Out of stock') : $t('Add to cart') }}
                   <loader-background v-if="loading" class="t-bottom-0" height="t-h-1" bar="t-bg-base-lightest t-opacity-25" />
                 </button-component>
                 <add-to-wishlist :product="product" class="t-flex-fix t-mb-4" />
@@ -240,6 +240,9 @@ export default {
       }
 
       return this.$v.$invalid || this.loading || !this.quantity
+    },
+    isSizeSelectDisabled () {
+      return false
     },
     isSingleOptionProduct () {
       return this.product.type_id === 'simple' || this.isOnesizeProduct

--- a/src/themes/icmaa-imp/resource/i18n/cs-CZ.csv
+++ b/src/themes/icmaa-imp/resource/i18n/cs-CZ.csv
@@ -222,6 +222,7 @@
 "Order-Review","Kontrola objednávky"
 "Orders","Orders"
 "Our {department}","Naše {oddělení}"
+"Out of stock","Není skladem"
 "Participate now!","Zúčastněte se hned!"
 "Password has successfully been changed","Heslo bylo úspěšně změněno"
 "Password must have at least 8 letters.","Heslo musí obsahovat nejméně 8 písmen."

--- a/src/themes/icmaa-imp/resource/i18n/de-DE.csv
+++ b/src/themes/icmaa-imp/resource/i18n/de-DE.csv
@@ -213,6 +213,7 @@
 "Order-Review","Bestellbewertung"
 "Orders","Bestellungen"
 "Our {department}","Unsere {department}"
+"Out of stock","Ausverkauft"
 "Participate now!","Jetzt teilnehmen"
 "Password has successfully been changed","Das Passwort wurde erfolgreich geändert"
 "Password must have at least 8 letters.","Das Passwort muss mindestens 8 Zeichen enthalten."

--- a/src/themes/icmaa-imp/resource/i18n/en-US.csv
+++ b/src/themes/icmaa-imp/resource/i18n/en-US.csv
@@ -215,6 +215,7 @@
 "Order-Review","Order-Review"
 "Orders","Orders"
 "Our {department}","Our {department}"
+"Out of stock","Out of stock"
 "Participate now!","Participate now!"
 "Password has successfully been changed","Password has successfully been changed"
 "Password must have at least 8 letters.","Password must have at least 8 letters."

--- a/src/themes/icmaa-imp/resource/i18n/es-ES.csv
+++ b/src/themes/icmaa-imp/resource/i18n/es-ES.csv
@@ -219,6 +219,7 @@
 "Order-Review","Reseña-Pedido"
 "Orders","Pedidos"
 "Our {department}","Nuestro {departmento}"
+"Out of stock","Agotado"
 "Participate now!","¡Participar ahora!"
 "Password has successfully been changed","La contraseña ha sido cambiada satisfactoriamente"
 "Password must have at least 8 letters.","La contraseña tiene que tener al menos 8 letras."

--- a/src/themes/icmaa-imp/resource/i18n/fi-FI.csv
+++ b/src/themes/icmaa-imp/resource/i18n/fi-FI.csv
@@ -220,6 +220,7 @@
 "Order-Review","Tilaus-Esikatselu"
 "Orders","Orders"
 "Our {department}","Meidän {department}"
+"Out of stock","Loppu varastosta"
 "Participate now!","Osallistu nyt!"
 "Password has successfully been changed","Salasanasi on vaihdettu onnistuneesti"
 "Password must have at least 8 letters.","Salasanassa pitää olla väh. 8 kirjainta."

--- a/src/themes/icmaa-imp/resource/i18n/fr-FR.csv
+++ b/src/themes/icmaa-imp/resource/i18n/fr-FR.csv
@@ -222,6 +222,7 @@
 "Order-Review","Avis postés"
 "Orders","Commandes"
 "Our {department}","Nos {department}"
+"Out of stock","Épuisé"
 "Participate now!","Participez dès maintenant!"
 "Password has successfully been changed","Vos mot de passe a été modifié avec succès!"
 "Password must have at least 8 letters.","Votre mot de passe doit contenir au moins 8 caractères."

--- a/src/themes/icmaa-imp/resource/i18n/it-IT.csv
+++ b/src/themes/icmaa-imp/resource/i18n/it-IT.csv
@@ -220,6 +220,7 @@
 "Order-Review","Rivedi l'ordine"
 "Orders","Ordini"
 "Our {department}","Il nostro {department}"
+"Out of stock","Non disponibile"
 "Participate now!","Partecipa ora!"
 "Password has successfully been changed","La password è stata modificata con successo"
 "Password must have at least 8 letters.","La password deve avere almeno 8 lettere."

--- a/src/themes/icmaa-imp/resource/i18n/pl-PL.csv
+++ b/src/themes/icmaa-imp/resource/i18n/pl-PL.csv
@@ -221,6 +221,7 @@
 "Order-Review","Recenzja zamówienia"
 "Orders","Zamówienia"
 "Our {department}","Nasz {dział}"
+"Out of stock","Brak w magazynie"
 "Participate now!","Weź udział już teraz"
 "Password has successfully been changed","Hasło zostało pomyślnie zmienione"
 "Password must have at least 8 letters.","Hasło musi zawierać co najmniej 8 liter."

--- a/src/themes/icmaa-imp/resource/i18n/pt-BR.csv
+++ b/src/themes/icmaa-imp/resource/i18n/pt-BR.csv
@@ -221,6 +221,7 @@
 "Order-Review","Revisão de encomenda"
 "Orders","Encomendas"
 "Our {department}","O nosso {department}"
+"Out of stock","Fora de estoque"
 "Participate now!","Participa já!"
 "Password has successfully been changed","A password foi alterada com sucesso"
 "Password must have at least 8 letters.","A password deve conter pelo menos 8 letras."

--- a/src/themes/icmaa-imp/resource/i18n/sv-SE.csv
+++ b/src/themes/icmaa-imp/resource/i18n/sv-SE.csv
@@ -221,6 +221,7 @@
 "Order-Review","Recension av order"
 "Orders","Beställningar"
 "Our {department}","Vår (avdelning)"
+"Out of stock","Slut i lager"
 "Participate now!","Delta nu! "
 "Password has successfully been changed","Lösenordet har blivit ändrat"
 "Password must have at least 8 letters.","Lösenordet måste innehålla minst 8 bokstäver"


### PR DESCRIPTION
* If a product is selected, but is out-of-stock (checked via API against Magento on select), show a message and make it possible to select another size