### PR TITLE
#204222 Show `commonphrases` in description-tab on PDP

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Product/ProductDetails.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Product/ProductDetails.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+import { icmaa_catalog } from 'config'
 import { mapGetters } from 'vuex'
 import { stripHTML } from '@vue-storefront/core/filters/strip-html'
 import ProductAttributes from 'theme/components/core/blocks/Product/ProductAttributes'
@@ -84,7 +85,10 @@ export default {
         return false
       }
 
+      const importantPhrases = icmaa_catalog.entities.product.importantCommonphrases || []
+
       return this.product.commonphrases
+        .filter(id => importantPhrases.includes(id))
         .map(id => this.getOptionLabel({ attributeKey: 'commonphrases', optionId: this.product.commonphrases }))
     }
   },

--- a/src/themes/icmaa-imp/components/core/blocks/Product/ProductDetails.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Product/ProductDetails.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="t-text-sm">
     <div class="description t-whitespace-pre-line" v-text="stripHTML(product.description.trim())" />
+    <ul class="commonphrases" v-if="commonphrases">
+      <li v-for="(phrase, i) in commonphrases" :key="i" class="t-mt-2">
+        <span class="t-font-bold t-mr-1" v-if="i === 0">{{ $t('Notice:') }}</span>
+        {{ phrase }}
+      </li>
+    </ul>
     <no-ssr>
       <ul class="attributes t-mt-6" v-if="attributes.length > 0">
         <product-attributes
@@ -68,6 +74,18 @@ export default {
     },
     departmentAdvice () {
       return this.product.department === 6
+    },
+    commonphrases () {
+      if (
+        !this.product.commonphrases ||
+        this.product.commonphrases.length === 0 ||
+        this.product.commonphrases[0] === ''
+      ) {
+        return false
+      }
+
+      return this.product.commonphrases
+        .map(id => this.getOptionLabel({ attributeKey: 'commonphrases', optionId: this.product.commonphrases }))
     }
   },
   methods: {

--- a/src/themes/icmaa-imp/resource/i18n/de-DE.csv
+++ b/src/themes/icmaa-imp/resource/i18n/de-DE.csv
@@ -195,6 +195,7 @@
 "Not available in time","Nicht rechtzeitig lieferbar"
 "Not yet an account?","Noch kein Konto?"
 "Notice","Achtung Preorder"
+"Notice:","Anmerkung:"
 "Oh great, you are already subscribed.","Großartig, du bist bereits angemeldet."
 "Onesize","Onesize"
 "Only a few left","Nur noch wenige auf Lager"

--- a/src/themes/icmaa-imp/resource/i18n/en-US.csv
+++ b/src/themes/icmaa-imp/resource/i18n/en-US.csv
@@ -199,6 +199,7 @@
 "Not available in time","Not available in time"
 "Not yet an account?","Not yet an account?"
 "Notice","Notice"
+"Notice:","Notice:"
 "Oh great, you are already subscribed.","Oh great, you are already subscribed."
 "Onesize","Onesize"
 "Only a few left","Only a few left"


### PR DESCRIPTION
* Show important common phrase in description-tab on PDP
* They are configurable using an allow-list in configs: `icmaa_catalog.entities.product.importantCommonphrases`

Screenshot:
<img width="349" alt="Bildschirmfoto 2020-07-01 um 11 13 02" src="https://user-images.githubusercontent.com/6112764/86226354-d6fd6380-bb8b-11ea-8bac-06ae603aa1ae.png">
