### PR TITLE
#207001 Reduce bundle-size by removing `axios`

### DIFF
--- a/src/modules/icmaa-config/helpers/fetchResponseHandler.ts
+++ b/src/modules/icmaa-config/helpers/fetchResponseHandler.ts
@@ -1,0 +1,14 @@
+/**
+ * The fetch API don't throws an error if the status isn't successfull
+ * so we need to that on our own.
+ * @see https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
+ */
+
+const errorHandler = (response: Response): Response => {
+  if (!response.ok) {
+    throw Error(response.statusText)
+  }
+  return response
+}
+
+export default errorHandler

--- a/src/modules/icmaa-spotify/package.json
+++ b/src/modules/icmaa-spotify/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "axios": "^0.19.0"
+    "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
     "@vue-storefront/core": "^1.11.1"

--- a/src/modules/icmaa-spotify/store/actions.ts
+++ b/src/modules/icmaa-spotify/store/actions.ts
@@ -6,7 +6,7 @@ import SpotifyState from '../types/SpotifyState'
 import * as mutationTypes from './mutation-types'
 import { isCategoryInWhitelist } from '../helpers'
 
-import Axios from 'axios'
+import fetch from 'isomorphic-fetch'
 import config from 'config'
 import { processURLAddress } from '@vue-storefront/core/helpers'
 
@@ -16,8 +16,14 @@ const actions: ActionTree<SpotifyState, RootState> = {
   async fetchRelatedArtistsByName (context, name: string) {
     const { endpoint } = config.icmaa_spotify
     const apiUrl = endpoint + '/related-artists/' + encodeURIComponent(name)
-    return Axios.get(processURLAddress(apiUrl))
-      .then(resp => resp.data.result)
+    const fetchOptions = {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    }
+
+    return fetch(processURLAddress(apiUrl), fetchOptions)
+      .then(resp => resp.json())
+      .then(resp => resp.result)
       .catch(() => [])
   },
   async fetchRelatedArtistsByCategory (context, category: Category): Promise<any> {

--- a/src/modules/icmaa-spotify/store/actions.ts
+++ b/src/modules/icmaa-spotify/store/actions.ts
@@ -7,6 +7,7 @@ import * as mutationTypes from './mutation-types'
 import { isCategoryInWhitelist } from '../helpers'
 
 import fetch from 'isomorphic-fetch'
+import fetchErrorHandler from 'icmaa-config/helpers/fetchResponseHandler'
 import config from 'config'
 import { processURLAddress } from '@vue-storefront/core/helpers'
 
@@ -22,6 +23,7 @@ const actions: ActionTree<SpotifyState, RootState> = {
     }
 
     return fetch(processURLAddress(apiUrl), fetchOptions)
+      .then(fetchErrorHandler)
       .then(resp => resp.json())
       .then(resp => resp.result)
       .catch(() => [])

--- a/src/modules/icmaa-twitter/package.json
+++ b/src/modules/icmaa-twitter/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "axios": "^0.19.0"
+    "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
     "@vue-storefront/core": "^1.11.1"

--- a/src/modules/icmaa-twitter/store/actions.ts
+++ b/src/modules/icmaa-twitter/store/actions.ts
@@ -3,7 +3,7 @@ import RootState from '@vue-storefront/core/types/RootState'
 import TwitterState from '../types/TwitterState'
 import * as mutationTypes from './mutation-types'
 
-import Axios from 'axios'
+import fetch from 'isomorphic-fetch'
 import config from 'config'
 import { processURLAddress } from '@vue-storefront/core/helpers'
 
@@ -11,8 +11,14 @@ const actions: ActionTree<TwitterState, RootState> = {
   async fetchStatusFeed (context, screenName: string) {
     const { endpoint } = config.icmaa_twitter
     const apiUrl = endpoint + '/feed/' + encodeURIComponent(screenName) + '/3'
-    return Axios.get(processURLAddress(apiUrl))
-      .then(resp => resp.data.result && resp.data.result.items ? resp.data.result.items : [])
+    const fetchOptions = {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    }
+
+    return fetch(processURLAddress(apiUrl), fetchOptions)
+      .then(resp => resp.json())
+      .then(resp => resp.result && resp.result.items ? resp.result.items : [])
       .catch(() => [])
   },
   async loadStatusFeed ({ dispatch, state, commit }, screenName: string): Promise<any> {

--- a/src/modules/icmaa-twitter/store/actions.ts
+++ b/src/modules/icmaa-twitter/store/actions.ts
@@ -4,6 +4,7 @@ import TwitterState from '../types/TwitterState'
 import * as mutationTypes from './mutation-types'
 
 import fetch from 'isomorphic-fetch'
+import fetchErrorHandler from 'icmaa-config/helpers/fetchResponseHandler'
 import config from 'config'
 import { processURLAddress } from '@vue-storefront/core/helpers'
 
@@ -17,6 +18,7 @@ const actions: ActionTree<TwitterState, RootState> = {
     }
 
     return fetch(processURLAddress(apiUrl), fetchOptions)
+      .then(fetchErrorHandler)
       .then(resp => resp.json())
       .then(resp => resp.result && resp.result.items ? resp.result.items : [])
       .catch(() => [])

--- a/src/themes/icmaa-imp/components/core/blocks/Auth/FacebookLoginButton.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Auth/FacebookLoginButton.vue
@@ -98,8 +98,8 @@ export default {
         const { accessToken } = response.authResponse
 
         await this.process(this.$store.dispatch('user/facebookLogin', { accessToken, version }))
-          .catch(e => this.onFailure(e))
           .then(() => this.onSuccess())
+          .catch(e => this.onFailure(e))
       }
     },
     toggleLogin () {

--- a/src/themes/icmaa-imp/components/core/blocks/Twitter/TwitterStatusFeed.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Twitter/TwitterStatusFeed.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="twitter-feed">
-    <div class="placeholder" v-if="loading">
+    <div class="placeholder" v-if="loading || status.length === 0">
       <div v-for="(s, i) in limit" :key="i" class="t-bg-white t-mb-2 t-p-4 t-flex t-flex-col">
         <div class="t-h-4 t-bg-base-lightest t-mb-2" v-for="(l, j) in 3" :key="j" />
         <div class="t-flex t-items-center t-justify-between t-text-xs t-text-base-lighter">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4824,13 +4824,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -7563,7 +7556,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -9250,13 +9243,6 @@ fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.10.0"


### PR DESCRIPTION
* `axios` has a 300kb+ package-size and we use only a small list of features so we switch to the `isomorphic-fetch` polyfill (8kb) which is already in use for all the other requests made in VSF
* As we use the `fetch` API we need to handle non-okay responses using a [small workaround](https://www.tjvantoll.com/2015/09/13/fetch-and-errors/) as `fetch` is handling responses to a specific standard