### PR TITLE
#208829 Don't flush local-storage after new build when Cypress.io is running

### DIFF
--- a/src/modules/icmaa-config/index.ts
+++ b/src/modules/icmaa-config/index.ts
@@ -21,7 +21,7 @@ export const IcmaaExtendedConfigModule: StorefrontModule = function ({ store }) 
       store.dispatch('icmaaConfig/setMap')
     })
 
-    if (!isServer) {
+    if (!isServer && !(window as any).Cypress) {
       coreHooks.afterAppInit(async () => {
         const configStorage = StorageManager.get(cacheStorageKey)
 


### PR DESCRIPTION
* We are settings some local-storage values to hide modals and stuff on initial load, these would be deleted again