### PR TITLE
Improve splitting reg-exp for search-aliases in search-panel

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -132,7 +132,7 @@ export default {
   },
   methods: {
     async getAlias (searchString) {
-      const wordsRegexp = /(\w+)/giu
+      const wordsRegexp = /([^\s_\-."']+)/giu
       let wordResult = ''
       let replaces = []
 


### PR DESCRIPTION
* This way it splits all words correctly and keeps the special chars