### PR TITLE
Bugfix for `icmaa-category-extras` module

### DIFF
--- a/src/modules/icmaa-category-extras/mixins/categoryExtras.ts
+++ b/src/modules/icmaa-category-extras/mixins/categoryExtras.ts
@@ -1,4 +1,5 @@
 import { isServer } from '@vue-storefront/core/helpers'
+import isEmpty from 'lodash-es/isEmpty'
 
 export default {
   async asyncData ({ store, route }) {
@@ -24,8 +25,10 @@ export default {
     this.fetchAsyncData()
   },
   watch: {
-    getCurrentCategory: function () {
-      this.fetchAsyncData()
+    getCurrentCategory: function (category, lastCategory) {
+      if (category && !isEmpty(category) && category.url_key !== lastCategory.url_key) {
+        this.fetchAsyncData()
+      }
     }
   },
   methods: {
@@ -35,7 +38,7 @@ export default {
     },
     async fetchAsyncData () {
       const category = this.$store.getters['category-next/getCurrentCategory']
-      if (category) {
+      if (category && !isEmpty(category)) {
         await Promise.all([
           this.$store.dispatch('icmaaSpotify/fetchRelatedArtists', category),
           this.fetchContentHeader(category.url_key)

--- a/src/modules/icmaa-category-extras/store/actions.ts
+++ b/src/modules/icmaa-category-extras/store/actions.ts
@@ -56,6 +56,10 @@ const actions: ActionTree<CategoryExtrasState, RootState> = {
     context.commit(types.ICMAA_CATEGORY_EXTRAS_CHILDCATEGORIES_ADD, childrenArray)
   },
   loadContentHeader: async ({ commit, getters }, identifier: string): Promise<CategoryExtrasContentHeader|any[]> => {
+    if (!identifier) {
+      return
+    }
+
     const existingContentHeader = getters.getContentHeaderByUrlKey(identifier)
     if (existingContentHeader) {
       return existingContentHeader


### PR DESCRIPTION
* Prevent loading category-extras on unload and/or without identifier
* The category watcher of the CLP mixin would call category-extras when route is left because of the changing (emptying) category state value