### PR TITLE
#210379 Bugfix for add-to-cart routine and login to existing quote

### DIFF
--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -60,7 +60,7 @@ const actions: ActionTree<UserState, RootState> = {
     const resp = await UserService.login(username, password)
     userHooksExecutors.afterUserAuthorize(resp)
 
-    if (resp && resp.code === 200) {
+    if (resp.code === 200) {
       try {
         await dispatch('resetUserInvalidateLock', {}, { root: true })
         commit(types.USER_TOKEN_CHANGED, { newToken: resp.result, meta: resp.meta }) // TODO: handle the "Refresh-token" header
@@ -69,9 +69,6 @@ const actions: ActionTree<UserState, RootState> = {
         await dispatch('clearCurrentUser')
         throw new Error(err)
       }
-    } else {
-      Logger.error('Login response error:', 'user', resp)()
-      throw new Error('Server response is invalid')
     }
 
     return resp

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -60,7 +60,7 @@ const actions: ActionTree<UserState, RootState> = {
     const resp = await UserService.login(username, password)
     userHooksExecutors.afterUserAuthorize(resp)
 
-    if (resp.code === 200) {
+    if (resp && resp.code === 200) {
       try {
         await dispatch('resetUserInvalidateLock', {}, { root: true })
         commit(types.USER_TOKEN_CHANGED, { newToken: resp.result, meta: resp.meta }) // TODO: handle the "Refresh-token" header
@@ -69,6 +69,9 @@ const actions: ActionTree<UserState, RootState> = {
         await dispatch('clearCurrentUser')
         throw new Error(err)
       }
+    } else {
+      Logger.error('Login response error:', 'user', resp)()
+      throw new Error('Server response is invalid')
     }
 
     return resp

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -10,6 +10,23 @@ import * as types from '../store/mutation-types'
 import * as orgTypes from '@vue-storefront/core/modules/cart/store/mutation-types'
 
 const actions: ActionTree<CartState, RootState> = {
+  /**
+   * There is a bug in the original method where the method assumes that `getCoupon` always returns an object.
+   * This sometimes leads to an exception during the login if a cart exists and the user wants to login into
+   * a customer account with a exsisting quote.
+   */
+  async authorize ({ dispatch, getters }) {
+    const coupon = getters.getCoupon ? getters.getCoupon.code : false
+    if (coupon) {
+      await dispatch('removeCoupon', { sync: false })
+    }
+
+    await dispatch('connect', { guestCart: false, mergeQty: true })
+
+    if (coupon) {
+      await dispatch('applyCoupon', coupon)
+    }
+  },
   async reconnect ({ dispatch, commit }, { token, forceClientState = false }) {
     Logger.info('Reconnect quote with:', 'cart', token)()
 

--- a/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
@@ -19,10 +19,11 @@ export default {
       try {
         /**
          * Note: There was a bug which causes the first attemp to put an item in cart to fail without message.
-         * That was because the `cart/create` action, which is called during the add-to-cart action, calls the `cart/connect` action
-         * which again runs the cart sync-/merge-actions and empties the cart again because the server response is empty and there is not yet
-         * a `cartToken`. I could fix this by disabling `cart.serverMergeByDefault`. This will run the `cart/sync` action in `cart/connect`
-         * action with the `dryRun` parameter and prevent the cart diffLog to be emptied.
+         **
+         * It's important to have `serverMergeByDefault` enabled to synchronize an existing customer cart but
+         * `serverSyncCanRemoveLocalItems` and `serverSyncCanModifyLocalItems` disabled. Only this way we prevent
+         * the `synchronizeServerItem` method during server- and client-cart-merge to remove the new item from cart again
+         * if the cart was empty at first. This is a misconception of the VSF.
          */
         const diffLog = await this.$store.dispatch('cart/addItem', { productToAdd: product })
 


### PR DESCRIPTION
 * It's important to have `serverMergeByDefault` enabled to synchronize an existing customer cart but `serverSyncCanRemoveLocalItems` and `serverSyncCanModifyLocalItems` disabled. Only this way we prevent the `synchronizeServerItem` method during server- and client-cart-merge to remove the new item from cart again if the cart was empty at first. This is a misconception of the VSF.