### PR TITLE
#210657 Improve search-sidebar

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/Sidebar.vue
@@ -5,7 +5,9 @@
       <h2 class="t-pl-2 t-text-lg t-text-base-dark" v-if="title" v-text="title" />
       <slot name="top-after-title" />
       <div class="t-flex-expand" v-if="useExpanderInTitle" />
-      <top-button data-test-id="closeButton" :icon="closeIcon" text="Close" :tab-index="1" @click.native="closeMenu" class="t-text-base" />
+      <slot name="top-right">
+        <top-button data-test-id="closeButton" :icon="closeIcon" text="Close" :tab-index="1" @click.native="closeMenu" class="t-text-base" v-if="closeIcon !== false" />
+      </slot>
     </div>
     <div class="spacer t-h-60px" />
     <div @click="closeAfterClick" class="sidebar-content t-p-4">

--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -1,12 +1,14 @@
 <template>
   <sidebar :close-on-click="false" :use-expander-in-title="false" ref="searchSidebar" data-test-id="SearchPanel">
     <template v-slot:top>
-      <material-icon icon="keyboard_arrow_left" class="t-mx-2 t-cursor-pointer" @click.native="closeSidebar" />
-      <label for="search" class="t-flex">
+      <div class="t-flex t-self-stretch t-items-center t-px-2 t-cursor-pointer" data-test-id="closeButton" @click="closeSidebar">
+        <material-icon icon="keyboard_arrow_left" />
+      </div>
+      <label for="search" class="t-flex t-self-stretch t-items-center">
         <span class="t-sr-only">{{ $t('Search') }}</span>
-        <material-icon icon="search" size="sm" class="t-text-base-light t-ml-2 t-mr-1" />
+        <material-icon icon="search" size="sm" class="t-text-base-light t-pl-2 t-pr-1" />
       </label>
-      <input type="text" v-model="searchString" @input="search" @blur="$v.searchString.$touch()" :placeholder="$t('Type what you are looking for...')" autofocus="true" data-test-id="SearchInput" ref="searchString" class="t-flex-expand t-p-0 t-text-lg t-text-base-tone placeholder:t-text-base-lighter">
+      <input type="text" v-model="searchString" @input="search" @blur="$v.searchString.$touch()" id="search" :placeholder="$t('Type what you are looking for...')" autofocus="true" data-test-id="SearchInput" ref="searchString" class="t-self-stretch t-flex-expand t-p-0 t-text-lg t-text-base-tone placeholder:t-text-base-lighter">
     </template>
     <template v-slot:top-right>
       <top-button icon="close" text="Close" @click.native="emptySearchInput" v-show="searchString.length > 0" />

--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -95,14 +95,7 @@ export default {
       return this.$store.state.search
     },
     filteredProducts () {
-      const productList = this.products || []
-      if (this.selectedCategoryIds.length) {
-        return productList.filter(product => product.category_ids.some(categoryId => {
-          const catId = parseInt(categoryId)
-          return this.selectedCategoryIds.includes(catId)
-        }))
-      }
-      return productList
+      return this.products || []
     },
     categories () {
       const splitChars = [' ', '-', ',']
@@ -134,8 +127,8 @@ export default {
     }
   },
   watch: {
-    categoryAggs () {
-      this.selectedCategoryIds = []
+    selectedCategoryIds () {
+      this.search()
     }
   },
   methods: {
@@ -228,6 +221,12 @@ export default {
         .applyFilter({ key: 'stock', value: '' })
         .applyFilter({ key: 'visibility', value: { 'in': [3, 4] } })
         .applyFilter({ key: 'status', value: { 'in': [0, 1] } })
+
+      if (this.selectedCategoryIds.length > 0) {
+        this.selectedCategoryIds.forEach(cid => {
+          searchQuery.applyFilter({ key: 'category_ids', value: { 'in': [cid] } })
+        })
+      }
 
       return searchQuery
     },

--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -1,11 +1,15 @@
 <template>
   <sidebar :close-on-click="false" :use-expander-in-title="false" ref="searchSidebar" data-test-id="SearchPanel">
     <template v-slot:top>
+      <material-icon icon="keyboard_arrow_left" class="t-mx-2 t-cursor-pointer" @click.native="closeSidebar" />
       <label for="search" class="t-flex">
         <span class="t-sr-only">{{ $t('Search') }}</span>
-        <material-icon icon="search" class="t-mx-2" />
+        <material-icon icon="search" size="sm" class="t-text-base-light t-ml-2 t-mr-1" />
       </label>
       <input type="text" v-model="searchString" @input="search" @blur="$v.searchString.$touch()" :placeholder="$t('Type what you are looking for...')" autofocus="true" data-test-id="SearchInput" ref="searchString" class="t-flex-expand t-p-0 t-text-lg t-text-base-tone placeholder:t-text-base-lighter">
+    </template>
+    <template v-slot:top-right>
+      <top-button icon="close" text="Close" @click.native="emptySearchInput" v-show="searchString.length > 0" />
     </template>
     <div class="t-pb-20">
       <div v-if="getNoResultsMessage" class="t-px-2 t-mt-2 t-mb-4 t-text-sm">
@@ -34,6 +38,7 @@ import Sidebar from 'theme/components/core/blocks/AsyncSidebar/Sidebar'
 import ProductTile from 'theme/components/core/ProductTile'
 import CategoryPanel from 'theme/components/core/blocks/SearchPanel/CategoryPanel'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
+import TopButton from 'theme/components/core/blocks/AsyncSidebar/TopButton'
 import ButtonComponent from 'theme/components/core/blocks/Button'
 import LoaderBackground from 'theme/components/core/LoaderBackground'
 import VueOfflineMixin from 'vue-offline/mixin'
@@ -55,6 +60,7 @@ export default {
     ProductTile,
     CategoryPanel,
     MaterialIcon,
+    TopButton,
     ButtonComponent,
     LoaderBackground
   },
@@ -239,6 +245,10 @@ export default {
           this.categoryAggs.push(cat)
         })
       }
+    },
+    emptySearchInput () {
+      Object.assign(this.$data, this.$options.data.apply(this))
+      this.$refs.searchString.focus()
     },
     closeSidebar () {
       this.$store.dispatch('ui/setSidebar', { key: 'searchpanel', status: false })


### PR DESCRIPTION
* Add better logic for empty/close routine of search-sidebar-panel
* Improve click-areas for buttons/inputs in search-sidebar
* Add an actual filter to search-results on category-filter buttons, instead of just search the first X results. This otherwise leads into the problem that items that aren't on the first result-page won't be able to filter for and no results are shown.
