### PR TITLE
Improve implementation of `storage-manager`

### DIFF
--- a/src/modules/icmaa-advice/index.ts
+++ b/src/modules/icmaa-advice/index.ts
@@ -5,8 +5,8 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { AdviceStore, adviceStateKey } from './store'
 
 export const KEY = 'icmaa-advice'
-export const cacheStorage = StorageManager.init(KEY, undefined, 512)
 
 export const IcmaaAdviceModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(KEY, undefined, 512)
   store.registerModule(adviceStateKey, AdviceStore)
 }

--- a/src/modules/icmaa-category-extras/index.ts
+++ b/src/modules/icmaa-category-extras/index.ts
@@ -4,8 +4,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 import { CategoryExtrasStore, categoryExtrasStateKey, categoryExtrasStorageKey } from './store'
 
-export const cacheStorage = StorageManager.init(categoryExtrasStorageKey, undefined, 2048)
-
 export const IcmaaCategoryExtrasModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(categoryExtrasStorageKey, undefined, 2048)
   store.registerModule(categoryExtrasStateKey, CategoryExtrasStore)
 }

--- a/src/modules/icmaa-competitions/index.ts
+++ b/src/modules/icmaa-competitions/index.ts
@@ -5,9 +5,8 @@ import { setupMultistoreRoutes } from '@vue-storefront/core/lib/multistore'
 import { CompetitionsStore, competitionsStateKey, competitionsStorageKey } from './store'
 import moduleRoutes from './routes'
 
-export const cacheStorage = StorageManager.init(competitionsStorageKey, undefined, 128)
-
 export const IcmaaCompetitionsModule: StorefrontModule = async function ({ store, appConfig, router }) {
+  StorageManager.init(competitionsStorageKey, undefined, 128)
   store.registerModule(competitionsStateKey, CompetitionsStore)
   setupMultistoreRoutes(appConfig, router, moduleRoutes, 10)
 }

--- a/src/modules/icmaa-config/index.ts
+++ b/src/modules/icmaa-config/index.ts
@@ -12,9 +12,10 @@ import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 export const cacheStorageKey = 'icmaa-config'
-export const cacheStorage = StorageManager.init(cacheStorageKey, false, config.server.elasticCacheQuota)
 
 export const IcmaaExtendedConfigModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(cacheStorageKey, undefined, config.server.elasticCacheQuota)
+
   if (config.storeViews.multistore === true) {
     store.registerModule('icmaaConfig', ExtendedConfigStore)
     coreHooks.afterAppInit(() => {

--- a/src/modules/icmaa-forms/index.ts
+++ b/src/modules/icmaa-forms/index.ts
@@ -4,8 +4,8 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { FormsStore, formsStateKey, formsStorageKey } from './store'
 
 export const KEY = formsStorageKey
-export const cacheStorage = StorageManager.init(formsStorageKey, undefined, 128)
 
 export const IcmaaFormsModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(formsStorageKey, undefined, 128)
   store.registerModule(formsStateKey, FormsStore)
 }

--- a/src/modules/icmaa-recommendations/index.ts
+++ b/src/modules/icmaa-recommendations/index.ts
@@ -3,8 +3,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 import { RecommendationsStore, storageKey, stateKey } from './store'
 
-export const cacheStorage = StorageManager.init(storageKey, undefined, 512)
-
 export const IcmaaRecommendationsModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(storageKey, undefined, 512)
   store.registerModule(stateKey, RecommendationsStore)
 }

--- a/src/modules/icmaa-spotify/index.ts
+++ b/src/modules/icmaa-spotify/index.ts
@@ -5,8 +5,8 @@ import { SpotifyStore } from './store'
 
 export const KEY = 'icmaa-spotify'
 export const storageKey = 'spotify'
-export const cacheStorage = StorageManager.init(KEY, undefined, 128)
 
 export const IcmaaSpotifyModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(KEY, undefined, 128)
   store.registerModule('icmaaSpotify', SpotifyStore)
 }

--- a/src/modules/icmaa-teaser/index.ts
+++ b/src/modules/icmaa-teaser/index.ts
@@ -6,9 +6,9 @@ import { TeaserStore, teaserStateKey } from './store'
 import moduleRoutes from './routes'
 
 export const KEY = 'icmaa-teaser'
-export const cacheStorage = StorageManager.init(KEY, undefined, 1024)
 
 export const IcmaaTeaserModule: StorefrontModule = function ({ store, appConfig, router }) {
+  StorageManager.init(KEY, undefined, 1024)
   store.registerModule(teaserStateKey, TeaserStore)
   setupMultistoreRoutes(appConfig, router, moduleRoutes, 10)
 }

--- a/src/modules/icmaa-twitter/index.ts
+++ b/src/modules/icmaa-twitter/index.ts
@@ -4,8 +4,8 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { TwitterStore } from './store'
 
 export const KEY = 'icmaa-twitter'
-export const cacheStorage = StorageManager.init(KEY, undefined, 512)
 
 export const IcmaaTwitterModule: StorefrontModule = function ({ store }) {
+  StorageManager.init(KEY, undefined, 512)
   store.registerModule('icmaaTwitter', TwitterStore)
 }


### PR DESCRIPTION
* We currently called `init` in a scope where no "current" store can be assigned, thats why the storage mostly wasn't localized in our modules (these whose loaded initially)
* The flush of the local-storage after a new build only worked for the first called store-view, I made the `icmaa-config` storage localized so that the routine to check the build-time is store-based as well