### PR TITLE
Bugfix for missing country-flag in `/en`

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Header/LanguageSwitcher.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Header/LanguageSwitcher.vue
@@ -1,24 +1,19 @@
 <template>
   <div class="t-hidden sm:t-flex t-border-l t-border-base-tone t-items-stretch">
     <div class="t-flex t-items-center t-cursor-pointer  t-px-4" @click="showLanguagesModal">
-      <flag-icon :iso="country" width="20" height="20" class="t-flex t-w-6 t-h-6 t-rounded-full t-border t-border-base-tone" />
+      <flag-icon :iso="languageCode" width="20" height="20" class="t-flex t-w-6 t-h-6 t-rounded-full t-border t-border-base-tone" />
     </div>
   </div>
 </template>
 
 <script>
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import FlagIcon from 'theme/components/core/blocks/FlagIcon'
+import FlagMixin from 'theme/mixins/flagMixin'
 
 export default {
+  mixins: [ FlagMixin ],
   components: {
     FlagIcon
-  },
-  data () {
-    const storeView = currentStoreView()
-    return {
-      country: storeView.i18n.defaultCountry
-    }
   },
   methods: {
     showLanguagesModal () {

--- a/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -22,7 +22,7 @@
             </template>
           </div>
           <div class="t-flex-expand t-border-base-lighter t-border-r t-h-8 t-mx-4" />
-          <flag-icon :iso="country" width="20" height="20" class="t-flex-initial t-w-5 t-h-5 t-cursor-pointer" @click.native="showLanguageSwitcher" />
+          <flag-icon :iso="languageCode" width="20" height="20" class="t-flex-initial t-w-5 t-h-5 t-cursor-pointer" @click.native="showLanguageSwitcher" />
         </div>
       </div>
     </template>
@@ -36,9 +36,11 @@ import Sidebar from 'theme/components/core/blocks/AsyncSidebar/Sidebar'
 import TopButton from 'theme/components/core/blocks/AsyncSidebar/TopButton'
 import NavigationItem from 'theme/components/core/blocks/SidebarMenu/NavigationItem'
 import FlagIcon from 'theme/components/core/blocks/FlagIcon'
+import FlagMixin from 'theme/mixins/flagMixin'
 
 export default {
   name: 'SidebarMenu',
+  mixins: [ FlagMixin ],
   components: {
     Sidebar,
     TopButton,
@@ -65,7 +67,6 @@ export default {
         Object.assign(link, { isRoute: (typeof link.route === 'object' || link.route.startsWith('/')) })
       ).slice(0, 3)
     },
-    country: () => currentStoreView().i18n.defaultCountry,
     loginButtonText () {
       return this.isLoggedIn ? 'My Account' : 'Login'
     }

--- a/src/themes/icmaa-imp/mixins/flagMixin.ts
+++ b/src/themes/icmaa-imp/mixins/flagMixin.ts
@@ -1,0 +1,23 @@
+import config from 'config'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+
+export default {
+  computed: {
+    languageSwitcherConfigs () {
+      return config.icmaa.languageSwitcher.map(l => ({
+        url: l[0],
+        storeCode: l[1],
+        languageCode: l[2],
+        name: l[3]
+      }))
+    },
+    languageSwitcherConfig () {
+      const { storeCode } = currentStoreView()
+      const flagCode = storeCode === 'en' ? 'eu' : storeCode
+      return this.languageSwitcherConfigs.find(c => c.languageCode === flagCode)
+    },
+    languageCode () {
+      return this.languageSwitcherConfig.languageCode
+    }
+  }
+}


### PR DESCRIPTION
* `/en` uses the EU flag as icon – this can't be found by store-code