### PR TITLE
#211292 Refactor how department/account related content is fetched

### DIFF
--- a/core/data-resolver/CategoryService.ts
+++ b/core/data-resolver/CategoryService.ts
@@ -43,6 +43,12 @@ const getCategories = async ({
   if (onlyNotEmpty === true) {
     searchQuery = searchQuery.applyFilter({ key: 'product_count', value: { 'gt': 0 } })
   }
+
+  if (typeof sort === 'object') {
+    searchQuery.applySort(sort)
+    sort = undefined
+  }
+
   const response = await quickSearchByQuery({ entityType: 'category', query: searchQuery, sort: sort, size: size, start: start, includeFields: includeFields, excludeFields: excludeFields })
   return response.items as Category[]
 }

--- a/core/data-resolver/types/DataResolver.d.ts
+++ b/core/data-resolver/types/DataResolver.d.ts
@@ -18,7 +18,7 @@ declare namespace DataResolver {
     onlyNotEmpty?: boolean,
     size?: number,
     start?: number,
-    sort?: string,
+    sort?: string|any,
     includeFields?: string[],
     excludeFields?: string[],
     reloadAll?: boolean

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -41,7 +41,7 @@ const getters: GetterTree<CategoryState, RootState> = {
       let valueCheck = []
       const searchOptions = getSearchOptionsFromRouteParams(params)
       forEach(searchOptions, (value, key) => valueCheck.push(category[key] && category[key] === (category[key].constructor)(value)))
-      return valueCheck.filter(check => check === true).length === Object.keys(searchOptions).length
+      return valueCheck.length > 0 && valueCheck.filter(check => check === true).length === Object.keys(searchOptions).length
     }) || {}
   },
   getCurrentCategory: (state, getters, rootState, rootGetters) => {

--- a/src/modules/icmaa-catalog/components/Product.ts
+++ b/src/modules/icmaa-catalog/components/Product.ts
@@ -12,11 +12,11 @@ export default {
       context.output.cacheTags.add(`product`)
     }
 
-    await store.dispatch('icmaaCategoryExtras/loadDepartmentChildCategoryIdMap')
+    const product = store.getters['product/getCurrentProduct']
+    const account = product.band || product.brand
 
-    const departmentCategoryId = store.getters['icmaaCategoryExtras/getCurrentProductDepartmentCategoryId']
-    if (departmentCategoryId) {
-      await store.dispatch('category-next/loadCategoryWithExtras', { filters: { 'id': departmentCategoryId } })
+    if (account) {
+      await store.dispatch('category-next/loadCategoryWithExtras', { filters: { 'ceAccount': account } })
 
       const category = store.getters['icmaaCategoryExtras/getCurrentProductDepartmentCategory']
       if (category) {

--- a/src/modules/icmaa-category-extras/README.md
+++ b/src/modules/icmaa-category-extras/README.md
@@ -8,7 +8,6 @@ Load and show category-extras from cms
   ```
   "icmaa_categoryextras": {
     "logoFilePath": "impericon/department-logos"
-    "parentDepartmentCategoryIds": [ 14, 16 ]
   }
   ```
   

--- a/src/modules/icmaa-category-extras/helpers/index.ts
+++ b/src/modules/icmaa-category-extras/helpers/index.ts
@@ -1,3 +1,13 @@
+import { Category } from '@vue-storefront/core/modules/catalog-next/types/Category'
+import mapKeys from 'lodash-es/mapKeys'
+import pick from 'lodash-es/pick'
+
 export const getCategoryExtrasKeyByAttribute = (type: string): string => {
   return 'ce' + (type as string).charAt(0).toUpperCase() + (type as string).slice(1)
+}
+
+export const mapCategoryExtrasAttributes = (category: Category) => {
+  const ceKeys = Object.keys(category).filter(k => /^ce[A-Z]/.test(k))
+  category = pick(category, ceKeys)
+  return mapKeys(category, (v, key) => key.charAt(2).toLowerCase() + key.slice(3))
 }

--- a/src/modules/icmaa-category-extras/store/actions.ts
+++ b/src/modules/icmaa-category-extras/store/actions.ts
@@ -8,52 +8,12 @@ import * as types from './mutation-types'
 import { categoryExtrasStateKey } from './'
 
 import { DataResolver } from '@vue-storefront/core/data-resolver/types/DataResolver'
-import { fetchChildCategories } from 'icmaa-category/helpers'
-import { icmaa_categoryextras } from 'config'
 import CmsService from 'icmaa-cms/data-resolver/CmsService'
 
-import { Logger } from '@vue-storefront/core/lib/logger'
-
 const actions: ActionTree<CategoryExtrasState, RootState> = {
-  async loadCategoryWithExtras ({ dispatch, getters }, categorySearchOptions: DataResolver.CategorySearchOptions): Promise<Category> {
+  async loadCategoryWithExtras ({ dispatch }, categorySearchOptions: DataResolver.CategorySearchOptions): Promise<Category> {
     categorySearchOptions.includeFields = config.entities.category.includeFields.concat(config.icmaa_cms.categoryExtras.categoryAttributes)
     return dispatch('category-next/loadCategory', categorySearchOptions, { root: true })
-  },
-  loadDepartmentChildCategoryIdMap: async (context): Promise<void> => {
-    const parentId: number[] = icmaa_categoryextras.parentDepartmentCategoryIds || []
-    return context.dispatch('loadChildCategoryIdMap', parentId)
-  },
-  loadChildCategoryIdMap: async (context, parentId: number[]): Promise<void> => {
-    const childCategories: Category[]|void = await fetchChildCategories({ parentId, level: 10, onlyShowTargetLevelItems: false })
-      .then(resp => resp)
-      .catch(error => {
-        Logger.error('Error while fetching children of category: ' + parentId, 'icmaaCategoryExtras', error)()
-        return []
-      })
-
-    let children = {}
-    childCategories.forEach(category => {
-      const containsParentIdInPath = category.path.split('/').map(i => parseInt(i)).filter(id => parentId.includes(id))
-      if (containsParentIdInPath.length > 0) {
-        const categoryParentId = containsParentIdInPath[0]
-        if (!children[categoryParentId]) {
-          children[categoryParentId] = []
-        }
-        children[categoryParentId].push({
-          id: category.id,
-          url_key: category.url_key
-        })
-      }
-    })
-
-    let childrenArray = []
-    for (const parentId in children) {
-      childrenArray.push({
-        parentId: parseInt(parentId), children: children[parentId]
-      })
-    }
-
-    context.commit(types.ICMAA_CATEGORY_EXTRAS_CHILDCATEGORIES_ADD, childrenArray)
   },
   loadContentHeader: async ({ commit, getters }, identifier: string): Promise<CategoryExtrasContentHeader|any[]> => {
     if (!identifier) {

--- a/src/modules/icmaa-category-extras/store/index.ts
+++ b/src/modules/icmaa-category-extras/store/index.ts
@@ -11,7 +11,6 @@ export const categoryExtrasStorageKey = 'icmaa-category-extras'
 export const CategoryExtrasStore: Module<CategoryExtrasState, RootState> = {
   namespaced: true,
   state: {
-    childCategoryIdMap: [],
     categoryContentHeader: {}
   },
   getters,

--- a/src/modules/icmaa-category-extras/store/mutations.ts
+++ b/src/modules/icmaa-category-extras/store/mutations.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { MutationTree } from 'vuex'
 import * as types from './mutation-types'
-import CategoryExtrasState, { CategoryExtrasContentHeader, CategoryExtrasContentHeaderContent } from '../types/CategoryExtrasState'
+import CategoryExtrasState, { CategoryExtrasContentHeaderContent } from '../types/CategoryExtrasState'
 
 interface CategoryExtrasContentHeaderOptions {
   identifier: string,
@@ -9,11 +9,6 @@ interface CategoryExtrasContentHeaderOptions {
 }
 
 const mutations: MutationTree<CategoryExtrasState> = {
-  [types.ICMAA_CATEGORY_EXTRAS_CHILDCATEGORIES_ADD] (state, categories) {
-    const existingCategories = state.childCategoryIdMap.map(c => c.parentId)
-    categories = categories.filter(c => !existingCategories.includes(c.parentId))
-    state.childCategoryIdMap = [...state.childCategoryIdMap, ...categories]
-  },
   [types.ICMAA_CATEGORY_EXTRAS_CONTENT_HEADER_ADD] (state, { identifier, payload }: CategoryExtrasContentHeaderOptions) {
     Vue.set(state.categoryContentHeader, identifier, payload)
   },

--- a/src/modules/icmaa-category-extras/types/CategoryExtrasState.ts
+++ b/src/modules/icmaa-category-extras/types/CategoryExtrasState.ts
@@ -2,17 +2,8 @@ export interface CategoryExtras {
   hasLogo: boolean,
   logoline: boolean,
   product_logoline: boolean,
+  account?: string|boolean|null,
   [key: string]: any
-}
-
-export interface CategoryExtrasCategoryIdMapChildStateItem {
-  id: number,
-  url_key: string
-}
-
-export interface CategoryExtrasCategoryIdMapStateItem {
-  parentId: number,
-  children: CategoryExtrasCategoryIdMapChildStateItem[]
 }
 
 export interface CategoryExtrasContentHeader {
@@ -26,6 +17,5 @@ export interface CategoryExtrasContentHeaderContent {
 }
 
 export default interface CategoryExtrasState {
-  childCategoryIdMap: CategoryExtrasCategoryIdMapStateItem[],
   categoryContentHeader: CategoryExtrasContentHeader
 }

--- a/src/themes/icmaa-imp/components/core/ProductImage.vue
+++ b/src/themes/icmaa-imp/components/core/ProductImage.vue
@@ -88,9 +88,15 @@ export default {
     onLoaded () {
       if (this.loading === true) {
         this.loading = !this.loading
+
+        let current = false
+        if (this.$refs.image) {
+          current = this.$refs.image.currentSrc
+        }
+
         this.$emit(
           'load',
-          { original: this.image, current: this.$refs.image.currentSrc }
+          { original: this.image, current }
         )
       }
     }


### PR DESCRIPTION
As we weren't able to connect an account/department of with a category, it was hard to fetch the category-extra information of a product. We now have an `account` attribute attached to the category-extras which simplifies the logic of fetching category-extras data for product.

Changes:
* Replace `childCategoryIdMap` state routine by "fetch-by-account-id"
* Add new logoline logic, based on path search instead of parent-id map
* Add complex sort options to `CategoryService` class to be able to add a sorting in `storefront-query-builder` style
* Improve `getCategoryByParams` as it will return the first value of `state.categoriesMap` if no route-params are set
* Bugfix for `ProductImage` component 