### PR TITLE
Improve category-extras and -banner on PDP and CLP

### DIFF
--- a/core/i18n/resource/i18n/en-US.csv
+++ b/core/i18n/resource/i18n/en-US.csv
@@ -72,7 +72,7 @@
 "Thumbnail","Thumbnail"
 "Type what you are looking for...","Type what you are looking for..."
 "Unexpected authorization error. Check your Network conection.","Unexpected authorization error. Check your Network conection."
-"Vue Storefront", "Vue Storefront"
+"Vue Storefront","Vue Storefront"
 "You are going to pay for this order upon delivery.","You are going to pay for this order upon delivery."
 "You are logged in!","You are logged in!"
 "You are to pay for this order upon delivery.","You are to pay for this order upon delivery."

--- a/core/i18n/resource/i18n/it-IT.csv
+++ b/core/i18n/resource/i18n/it-IT.csv
@@ -71,7 +71,7 @@
 "Thumbnail","Miniatura"
 "Type what you are looking for...","Cerca nel catalogo..."
 "Unexpected authorization error. Check your Network conection.","Errore di autorizzazione inaspettato. Verifica la tua connesione."
-"Vue Storefront", "Vue Storefront"
+"Vue Storefront","Vue Storefront"
 "You are going to pay for this order upon delivery.","Pagherai questo ordine alla consegna."
 "You are logged in!","Accesso eseguito!"
 "You are to pay for this order upon delivery.","Pagherai questo ordine alla consegna."

--- a/src/modules/icmaa-catalog/store/category/actions/index.ts
+++ b/src/modules/icmaa-catalog/store/category/actions/index.ts
@@ -126,7 +126,7 @@ const actions: ActionTree<CategoryState, RootState> = {
   },
   /**
    * Changes:
-   * * Add category whitelist support to hide unimportant categories
+   * * Add category allowlist support to hide unimportant categories
    * * Don't load it using `loadCategories` because the result might overwrite the current category in state
    */
   async loadCategoryBreadcrumbs ({ dispatch, getters }, { category, currentRouteName, omitCurrent = false }) {
@@ -135,11 +135,11 @@ const actions: ActionTree<CategoryState, RootState> = {
     }
 
     let categoryHierarchyIds = _prepareCategoryPathIds(category).map(id => Number(id))
-    let whitelistCategoryHierarchyIds = intersection(categoryHierarchyIds, icmaa.breadcrumbs.whitelist)
-    if (whitelistCategoryHierarchyIds.length > 0) {
-      categoryHierarchyIds = union(whitelistCategoryHierarchyIds, categoryHierarchyIds.slice(-1))
+    let allowlistCategoryHierarchyIds = intersection(categoryHierarchyIds, icmaa.breadcrumbs.allowlist)
+    if (allowlistCategoryHierarchyIds.length > 0) {
+      categoryHierarchyIds = union(allowlistCategoryHierarchyIds, categoryHierarchyIds.slice(-1))
     } else {
-      categoryHierarchyIds = whitelistCategoryHierarchyIds
+      categoryHierarchyIds = allowlistCategoryHierarchyIds
     }
 
     const filters = { 'id': categoryHierarchyIds }

--- a/src/modules/icmaa-catalog/store/product/actions.ts
+++ b/src/modules/icmaa-catalog/store/product/actions.ts
@@ -41,24 +41,21 @@ const actions: ActionTree<ProductState, RootState> = {
    * Changes:
    * * Load only parent categories containing `icmaa.breadcrumbs.path` items in path
    * * This way we can prior categories of products to be used as parent category
+   * * Don't load categories using `loadingCategories` action as it will overwrite existing ones and
+   *   the category-extras will diappear
    */
   async loadProductBreadcrumbs ({ dispatch, rootGetters }, { product } = {}) {
     if (product && product.category_ids) {
-      const currentCategory = rootGetters['category-next/getCurrentCategory']
+      const currentCategory = rootGetters['icmaaCategoryExtras/getCurrentCategory']
 
       let breadcrumbCategory
-      const onlyActive = false
       const { path } = icmaa.breadcrumbs
-      const categoryFilters = Object.assign(
+      const filters = Object.assign(
         { 'id': [...product.category_ids], path },
         cloneDeep(config.entities.category.breadcrumbFilterFields)
       )
 
-      const categories = await dispatch(
-        'category-next/loadCategories',
-        { filters: categoryFilters, onlyActive, reloadAll: true },
-        { root: true }
-      )
+      const categories = await dispatch('category-next/findCategories', { filters }, { root: true })
 
       if (currentCategory && currentCategory.id && (categories.findIndex(category => category.id === currentCategory.id) >= 0)) {
         breadcrumbCategory = currentCategory // use current category if set and included in the filtered list

--- a/src/modules/icmaa-catalog/store/product/actions.ts
+++ b/src/modules/icmaa-catalog/store/product/actions.ts
@@ -48,10 +48,13 @@ const actions: ActionTree<ProductState, RootState> = {
     if (product && product.category_ids) {
       const currentCategory = rootGetters['icmaaCategoryExtras/getCurrentCategory']
 
+      const existingCategories = rootGetters['category-next/getCategories'].map(c => c.id)
+      const fetchCategories = product.category_ids.filter(id => !existingCategories.includes(id))
+
       let breadcrumbCategory
       const { path } = icmaa.breadcrumbs
       const filters = Object.assign(
-        { 'id': [...product.category_ids], path },
+        { id: fetchCategories, path },
         cloneDeep(config.entities.category.breadcrumbFilterFields)
       )
 

--- a/src/modules/icmaa-category-extras/store/actions.ts
+++ b/src/modules/icmaa-category-extras/store/actions.ts
@@ -15,7 +15,7 @@ const actions: ActionTree<CategoryExtrasState, RootState> = {
     categorySearchOptions.includeFields = config.entities.category.includeFields.concat(config.icmaa_cms.categoryExtras.categoryAttributes)
     return dispatch('category-next/loadCategory', categorySearchOptions, { root: true })
   },
-  loadContentHeader: async ({ commit, getters }, identifier: string): Promise<CategoryExtrasContentHeader|any[]> => {
+  loadContentHeader: async ({ getters }, identifier: string): Promise<CategoryExtrasContentHeader|any[]> => {
     if (!identifier) {
       return
     }

--- a/src/modules/icmaa-category-extras/store/getters.ts
+++ b/src/modules/icmaa-category-extras/store/getters.ts
@@ -58,7 +58,8 @@ const getters: GetterTree<CategoryExtrasState, RootState> = {
     const product = rootGetters['product/getCurrentProduct']
     if (product && product.category) {
       const { band, brand } = product
-      return getters.getCategoryBy('ceAccount', band || brand)
+      const account = band || brand
+      return account ? getters.getCategoryBy('ceAccount', account.toString()) : false
     }
 
     return false

--- a/src/modules/icmaa-category-extras/store/getters.ts
+++ b/src/modules/icmaa-category-extras/store/getters.ts
@@ -32,7 +32,8 @@ const getters: GetterTree<CategoryExtrasState, RootState> = {
     return category
   },
   getCategoryBy: (state, getters, rootState, rootGetters) => (key: string, value: any): Category|boolean => {
-    return rootGetters['category-next/getCategories'].find(c => c[key] === value)
+    /* eslint-disable eqeqeq */
+    return rootGetters['category-next/getCategories'].find(c => c[key] == value)
   },
   getLogolineItems: () => (categories: Category[], type: string|boolean = false): Logo[] => {
     let logos: Logo[] = []
@@ -59,7 +60,7 @@ const getters: GetterTree<CategoryExtrasState, RootState> = {
     if (product && product.category) {
       const { band, brand } = product
       const account = band || brand
-      return account ? getters.getCategoryBy('ceAccount', account.toString()) : false
+      return account ? getters.getCategoryBy('ceAccount', account) : false
     }
 
     return false

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isVisible">
-    <div class="category-header t-relative">
-      <retina-image :image="banner" @error="onBannerError" :alt="category.name" v-if="banner" class="t-w-screen" />
+    <div class="category-header t-relative" :class="{ 'loaded': !bannerLoading }">
+      <picture-component :src="banner" :width="bannerWidth" :height="bannerHeight" :sizes="bannerSizes" :placeholder="true" :ratio="`${bannerWidth}:${bannerHeight}`" :auto-reload="true" @load="onBannerLoad" @error="onBannerError" :alt="category.name" v-if="banner" img-class="t-w-screen" placeholder-class="t-w-screen lg:t-w-auto" />
       <div class="t-flex t-items-center t-justify-end t-absolute t-bottom-0 t-left-0 t-pb-6 t-px-6 t-w-full">
         <slot />
       </div>
@@ -17,7 +17,7 @@
 import { mapGetters } from 'vuex'
 import { getThumbnailPath } from '@vue-storefront/core/helpers'
 import DepartmentLogo from 'theme/components/core/blocks/CategoryExtras/DepartmentLogo'
-import RetinaImage from 'theme/components/core/blocks/RetinaImage'
+import PictureComponent from 'theme/components/core/blocks/Picture'
 
 import { isDatetimeInBetween } from 'icmaa-config/helpers/datetime'
 import sampleSize from 'lodash-es/sampleSize'
@@ -26,9 +26,27 @@ export default {
   name: 'CategoryExtrasHeader',
   components: {
     DepartmentLogo,
-    RetinaImage
+    PictureComponent
   },
   props: {
+    bannerDimensions: {
+      type: [Object],
+      default: () => ({
+        default: { width: 780, height: 240 },
+        fallback: { width: 1140, height: 240 }
+      })
+    },
+    bannerSizes: {
+      type: [Array],
+      default: () => [
+        // Order high-to-low is important
+        { media: '(min-width: 1280px)', width: 1280 },
+        { media: '(min-width: 1024px)', width: 992 },
+        { media: '(min-width: 640px)', width: 736 },
+        { media: '(min-width: 415px)', width: 640 },
+        { media: '(max-width: 415px)', width: 415 }
+      ]
+    },
     spotifyLogoLimit: {
       type: [Boolean, Number],
       default: false
@@ -36,6 +54,7 @@ export default {
   },
   data () {
     return {
+      bannerLoading: true,
       bannerExists: true
     }
   },
@@ -65,7 +84,13 @@ export default {
         banner = this.categoryExtras.bannerImage.replace('_mobile', '')
       }
 
-      return getThumbnailPath('/' + banner, 0, 0, 'media')
+      return banner
+    },
+    bannerWidth () {
+      return this.bannerExists ? this.bannerDimensions.default.width : this.bannerDimensions.fallback.width
+    },
+    bannerHeight () {
+      return this.bannerExists ? this.bannerDimensions.default.height : this.bannerDimensions.fallback.height
     },
     spotifyLogoItems () {
       return Object.values(this.getSpotifyLogoItems).slice(0, this.spotifyLogoLimit || this.logoLimitByViewport())
@@ -75,7 +100,11 @@ export default {
     isLast (index, array) {
       return index !== (array.length - 1)
     },
+    onBannerLoad () {
+      this.bannerLoading = false
+    },
     onBannerError () {
+      this.bannerLoading = true
       this.bannerExists = false
     },
     logoLimitByViewport () {

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -108,9 +108,9 @@ import ButtonComponent from 'theme/components/core/blocks/Button'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
 import LoaderBackground from 'theme/components/core/LoaderBackground'
 import BlockWrapper from 'icmaa-cms/components/Wrapper'
-
 import CategoryExtrasHeader from 'theme/components/core/blocks/CategoryExtras/Header'
 import CategoryExtrasFooter from 'theme/components/core/blocks/CategoryExtras/Footer'
+
 import CategoryMixin from 'icmaa-catalog/components/Category'
 import CategoryExtrasMixin from 'icmaa-category-extras/mixins/categoryExtras'
 import CategoryMetaMixin from 'icmaa-meta/mixins/categoryMeta'
@@ -268,11 +268,11 @@ export default {
 
 /** Only show cropped header on desktop */
 @media (min-width: 1024px) {
-  header .category-header {
+  header .category-header.loaded {
     padding-top: calc(4%*100/19);
     overflow: hidden;
 
-    & > img {
+    & picture > img {
       position: absolute;
       top: 50%;
       left: 0;

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -3,7 +3,7 @@
     <div class="t-container t-px-4">
       <div class="t--mx-4 lg:t-px-4 t-flex t-flex-wrap">
         <breadcrumbs class="breadcrumbs t-w-full t-my-8 t-hidden lg:t-flex" />
-        <category-extras-header class="t-bg-white t-border-b t-border-base-lightest" v-if="['xs', 'sm', 'md'].includes(viewport)" :spotify-logo-limit="spotifyLogoLimit" />
+        <category-extras-header class="t-bg-white t-border-b t-border-base-lightest" v-if="['xs', 'sm', 'md'].includes(viewport)" :banner-sizes="categoryHeaderBannerSizes" :spotify-logo-limit="spotifyLogoLimit" />
         <product-gallery
           class="product-gallery t-w-full t-border-base-lightest t-border-b t-bg-white lg:t-w-1/2 lg:t-border-b-0"
           :gallery="gallery.map(i => i.src)"
@@ -11,7 +11,7 @@
           :product="product"
         />
         <div class="t-w-full t-p-8 t-bg-white lg:t-w-1/2" :class="{ 'lg:t-flex lg:t-flex-col lg:t-justify-between': isPreorder }">
-          <category-extras-header class="t--mx-8 t--mt-8 t-mb-8 lg:t-pl-px t-border-b t-border-base-lightest" v-if="!['xs', 'sm', 'md'].includes(viewport)" :spotify-logo-limit="spotifyLogoLimit" />
+          <category-extras-header class="t--mx-8 t--mt-8 t-mb-8 lg:t-pl-px t-border-b t-border-base-lightest" v-if="!['xs', 'sm', 'md'].includes(viewport)" :banner-sizes="categoryHeaderBannerSizes" :spotify-logo-limit="spotifyLogoLimit" />
           <div class="t-flex t-flex-wrap">
             <h1 data-test-id="productName" class="t-flex-grow t-w-1/2 t-mb-0 t-leading-snug">
               <template v-if="typeof productName === 'object'">
@@ -288,6 +288,16 @@ export default {
     },
     spotifyLogoLimit () {
       return this.viewport === 'sm' ? 4 : 5
+    },
+    categoryHeaderBannerSizes () {
+      return [
+        // Order high-to-low is important
+        { media: '(min-width: 1280px)', width: 624 },
+        { media: '(min-width: 1024px)', width: 496 },
+        { media: '(min-width: 640px)', width: 768 },
+        { media: '(min-width: 415px)', width: 640 },
+        { media: '(max-width: 415px)', width: 415 }
+      ]
     }
   },
   methods: {

--- a/src/themes/icmaa-imp/resource/i18n/en-US.csv
+++ b/src/themes/icmaa-imp/resource/i18n/en-US.csv
@@ -123,7 +123,7 @@
 "Germany","Germany"
 "Get inspired","Get inspired"
 "Get the Impericon Newsletter & and get yourself a {voucher_value} gift.","Get the Impericon Newsletter & and get yourself a {voucher_value} gift."
-"Get your {voucher_value} Voucher", "Get your {voucher_value} Voucher"
+"Get your {voucher_value} Voucher","Get your {voucher_value} Voucher"
 "Give a feedback","Give a feedback"
 "Go review the order","Go review the order"
 "Go to Facebook","Go to Facebook"


### PR DESCRIPTION
* Bugfix for missing category-extras on PDP (category was overwritten by `product/loadProductBreadcrumbs`)
* Load category-header using the `picture` component and add preloading