### PR TITLE
Improve loading of category-extras and breadcrumbs

### DIFF
--- a/src/modules/icmaa-catalog/store/category/actions/index.ts
+++ b/src/modules/icmaa-catalog/store/category/actions/index.ts
@@ -129,7 +129,7 @@ const actions: ActionTree<CategoryState, RootState> = {
    * * Add category allowlist support to hide unimportant categories
    * * Don't load it using `loadCategories` because the result might overwrite the current category in state
    */
-  async loadCategoryBreadcrumbs ({ dispatch, getters }, { category, currentRouteName, omitCurrent = false }) {
+  async loadCategoryBreadcrumbs ({ dispatch }, { category, currentRouteName }) {
     if (!category) {
       return dispatch('breadcrumbs/set', { current: currentRouteName, routes: [] }, { root: true })
     }

--- a/src/modules/icmaa-catalog/store/product/actions.ts
+++ b/src/modules/icmaa-catalog/store/product/actions.ts
@@ -48,21 +48,21 @@ const actions: ActionTree<ProductState, RootState> = {
     if (product && product.category_ids) {
       const currentCategory = rootGetters['icmaaCategoryExtras/getCurrentCategory']
 
-      const existingCategories = rootGetters['category-next/getCategories'].map(c => c.id)
-      const fetchCategories = product.category_ids.filter(id => !existingCategories.includes(id))
-
       let breadcrumbCategory
-      const { path } = icmaa.breadcrumbs
-      const filters = Object.assign(
-        { id: fetchCategories, path },
-        cloneDeep(config.entities.category.breadcrumbFilterFields)
-      )
-
-      const categories = await dispatch('category-next/findCategories', { filters }, { root: true })
-
-      if (currentCategory && currentCategory.id && (categories.findIndex(category => category.id === currentCategory.id) >= 0)) {
+      if (currentCategory && currentCategory.id) {
         breadcrumbCategory = currentCategory // use current category if set and included in the filtered list
       } else {
+        const existingCategories = rootGetters['category-next/getCategories'].map(c => c.id)
+        const fetchCategories = product.category_ids.filter(id => !existingCategories.includes(id))
+
+        const { path } = icmaa.breadcrumbs
+        const filters = Object.assign(
+          { id: fetchCategories, path },
+          cloneDeep(config.entities.category.breadcrumbFilterFields)
+        )
+
+        const categories = await dispatch('category-next/findCategories', { filters }, { root: true })
+
         breadcrumbCategory = categories.sort((a, b) => (a.level > b.level) ? -1 : 1)[0] // sort starting by deepest level
       }
 

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
@@ -84,6 +84,11 @@ export default {
         banner = this.categoryExtras.bannerImage.replace('_mobile', '')
       }
 
+      // Always use @2x image
+      if (!/(@2x)(\.\w{3,})$/.test(banner)) {
+        return banner.replace(/(\.\w{3,})$/, `@2x$1`);
+      }
+
       return banner
     },
     bannerWidth () {

--- a/src/themes/icmaa-imp/mixins/lozadMixin.ts
+++ b/src/themes/icmaa-imp/mixins/lozadMixin.ts
@@ -4,28 +4,54 @@ import lozad from 'lozad'
  * We overwrite the default `load` method to have better support for <picture> tag.
  */
 export default {
+  data () {
+    return {
+      lazyloadObserver: undefined
+    }
+  },
   methods: {
-    lazyload ($el: any, options = {}) {
-      const defaults = {
-        load: (element: HTMLElement) => {
-          var isIE = typeof document !== 'undefined' && document['documentMode']
-          if (element.nodeName.toLowerCase() === 'picture') {
-            if (element.children) {
-              var sources = element.children
-              Object.values(sources).forEach(source => {
-                if (!isIE && source.nodeName.toLowerCase() !== 'source') return
-                const sourceSrc = source.getAttribute('data-src')
-                const sourceSrcSet = source.getAttribute('data-srcset')
-                if (sourceSrc) source.setAttribute('src', sourceSrc)
-                if (sourceSrcSet) source.setAttribute('srcset', sourceSrcSet)
-              })
-            }
-          }
+    lazyloadLoad (element: HTMLElement) {
+      var isIE = typeof document !== 'undefined' && document['documentMode']
+      if (element.nodeName.toLowerCase() === 'picture') {
+        if (element.children) {
+          var sources = element.children
+          Object.values(sources).forEach(source => {
+            if (!isIE && source.nodeName.toLowerCase() !== 'source') return
+            const sourceSrc = source.getAttribute('data-src')
+            const sourceSrcSet = source.getAttribute('data-srcset')
+            if (sourceSrc) source.setAttribute('src', sourceSrc)
+            if (sourceSrcSet) source.setAttribute('srcset', sourceSrcSet)
+          })
         }
       }
+    },
+    lazyload ($el: any, options: any = {}) {
+      /**
+       * We can't use native `enableAutoReload` option because this calls the original `load` method inside
+       * its event observer. So we need to add our own observer code and load it using our method.
+       */
+      if (options.enableAutoReload === true && (window && window['MutationObserver'])) {
+        delete options.enableAutoReload
 
-      const observer = lozad($el, Object.assign(defaults, options))
-      observer.observe()
+        const isLoaded = element => element.getAttribute('data-loaded') === 'true'
+        const attributeFilter = ['data-src', 'data-srcset']
+
+        const ImageMutationObserver = new MutationObserver(mutations => {
+          for (let entry of mutations) {
+            const parent = (entry.target as HTMLElement).parentElement
+            if (isLoaded(parent) && entry.type === 'attributes' && attributeFilter.indexOf(entry.attributeName) > -1) {
+              this.lazyloadLoad(parent)
+            }
+          }
+        })
+
+        ImageMutationObserver.observe($el, { subtree: true, attributes: true, attributeFilter })
+      }
+
+      const defaults = { load: this.lazyloadLoad }
+
+      this.lazyloadObserver = lozad($el, Object.assign(defaults, options))
+      this.lazyloadObserver.observe()
     }
   }
 }


### PR DESCRIPTION
* Load breadcrumbs more efficiently and only if needed
* Always load `@2x` variant as category-header image
* Add custom `MutationObserver` to `lozadMixin`
  * We can't just use native `enableAutoReload` option because this calls the original `load` method inside its event observer. So we need to add our own observer code and load it using our method