### PR TITLE
Small CMS bugfixes and translations

### DIFF
--- a/src/modules/icmaa-category/helpers/index.ts
+++ b/src/modules/icmaa-category/helpers/index.ts
@@ -59,12 +59,19 @@ export const fetchChildCategories = async (
     })
 }
 
-const SORT_PREFIX_REGEXP = /^(the\s)/gmi
+const SORT_PREFIX_REGEXP = /^(the|der|die|das)\s/gmi
+const SORT_REPLACE_REGEXP = /[^0-9a-zA-Z]/gm
 export const extractPrefix = (name) => name.replace(SORT_PREFIX_REGEXP, '')
+export const filterAlphanum = (name) => name
+  .replace(/[äÄ]/gmi, 'ae')
+  .replace(/[öÖ]/gmi, 'oe')
+  .replace(/[üÜ]/gmi, 'ue')
+  .replace(SORT_REPLACE_REGEXP, ' ')
+  .toLowerCase()
 
 export const sortByLetter = (a: Category, b: Category) => {
   const [aName, bName] = [extractPrefix(a.name), extractPrefix(b.name)]
-  return aName === bName ? 0 : aName < bName ? -1 : 1
+  return aName === bName ? 0 : filterAlphanum(aName) < filterAlphanum(bName) ? -1 : 1
 }
 
 export const getFilterHash = (filter: Record<string, any>|boolean) => {

--- a/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/AddToCartSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/AddToCartSidebar.vue
@@ -29,7 +29,7 @@
       </template>
       <div class="t-flex t-flex-wrap t-mt-4 t-w-full">
         <model :product="product" class="t-w-full t-p-4 t-mb-px t-bg-base-lightest t-text-sm t-text-base-tone" />
-        <router-link :to="localizedRoute('/service-size')" class="t-w-full t-p-4 t-bg-base-lightest t-text-sm t-text-primary" @click.native="$emit('close')">
+        <router-link :to="localizedRoute('/service-size')" class="t-w-full t-p-4 t-bg-base-lightest t-text-sm t-text-primary" @click.native="close()">
           {{ $t('Which size fits me?') }}
           <material-icon icon="call_made" size="md" class="t-float-right t-align-middle" />
         </router-link>

--- a/src/themes/icmaa-imp/components/core/blocks/Auth/Register.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Auth/Register.vue
@@ -134,9 +134,9 @@
           <div class="t-w-full t-text-xs t-text-base-lighter t-leading-1-rem lg:t-text-center">
             <material-icon icon="asterisk" icon-set="icmaa" size="xxs" class="t-mr-1" />
             <i18n path="I have read and agree with the {terms}, {policy} and {return}." tag="span">
-              <router-link place="terms" :to="localizedRoute('/terms')" v-html="$t('Terms and Conditions')" class="t-text-base-lighter t-underline" />
-              <router-link place="policy" :to="localizedRoute('/policy')" v-html="$t('Privacy Policy')" class="t-text-base-lighter t-underline" />
-              <router-link place="return" :to="localizedRoute('/return')" v-html="$t('Return Instructions')" class="t-text-base-lighter t-underline" />
+              <router-link place="terms" :to="localizedRoute('/service-conditions')" v-html="$t('Terms and Conditions')" class="t-text-base-lighter t-underline" @click.native="close()" />
+              <router-link place="policy" :to="localizedRoute('/service-imprint')" v-html="$t('Privacy Policy')" class="t-text-base-lighter t-underline" @click.native="close()" />
+              <router-link place="return" :to="localizedRoute('/service-return')" v-html="$t('Return Instructions')" class="t-text-base-lighter t-underline" @click.native="close()" />
             </i18n>
           </div>
         </div>

--- a/src/themes/icmaa-imp/components/core/blocks/ICMAA/Cms/Pages/Festival.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/ICMAA/Cms/Pages/Festival.vue
@@ -58,7 +58,9 @@
 
     <!-- Gallery-->
     <div class="t-flex t-flex-wrap">
-      <img v-for="galleryitem in content.gallery" :key="galleryitem.img" :src="getMediaThumbnail(galleryitem.img, 0, 0)" :alt="galleryitem.name" :title="galleryitem.name" class="t-w-1/2 md:t-w-1/3 lg:t-w-1/6">
+      <div v-for="galleryitem in content.gallery" :key="galleryitem.img" class="t-w-1/2 md:t-w-1/3 lg:t-w-1/6">
+        <picture-component :src="galleryitem.img" :width="600" :height="400" :sizes="galleryImgSizes" :placeholder="true" ratio="3:2" :alt="galleryitem.name" :title="galleryitem.name" />
+      </div>
     </div>
   </div>
 </template>
@@ -66,15 +68,28 @@
 <script>
 import Page from 'icmaa-cms/mixins/Page'
 import ButtonComponent from 'theme/components/core/blocks/Button'
+import PictureComponent from 'theme/components/core/blocks/Picture'
 
 export default {
   name: 'Festival',
   mixins: [ Page ],
-  components: { ButtonComponent },
+  components: {
+    ButtonComponent,
+    PictureComponent
+  },
   data () {
     return {
       dataType: 'yaml',
       currentTab: 0
+    }
+  },
+  computed: {
+    galleryImgSizes () {
+      return [
+        { media: '(min-width: 1024px)', width: 240 },
+        { media: '(min-width: 768px)', width: 300 },
+        { media: '(max-width: 414px)', width: 220 }
+      ]
     }
   }
 }

--- a/src/themes/icmaa-imp/resource/i18n/en-US.csv
+++ b/src/themes/icmaa-imp/resource/i18n/en-US.csv
@@ -68,6 +68,7 @@
 "Customer service (Magento CMS)","Customer service (Magento CMS)"
 "Customer service","Customer service"
 "DPD Courier","DPD Courier"
+"Data is not given to third parties and unsubscription is possible at any time. {policy}","Data is not given to third parties and unsubscription is possible at any time. {policy}"
 "Date and time","Date and time"
 "Date of birth","Date of birth"
 "Date","Date"


### PR DESCRIPTION
* Wrong links in register popup
* Close sidebar/popup on `router-link` click
* Add `en-US` translation
* Lazyload images on `/festival` page
* Improve sorting in category-list