### PR TITLE
#212288 Bugfix for `v-model` in `SearchPanel` and Android keyboard

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -8,7 +8,7 @@
         <span class="t-sr-only">{{ $t('Search') }}</span>
         <material-icon icon="search" size="sm" class="t-text-base-light t-pl-2 t-pr-1" />
       </label>
-      <input type="text" v-model="searchString" @input="onInput" @blur="$v.searchString.$touch()" id="search" :placeholder="$t('Type what you are looking for...')" autofocus="true" data-test-id="SearchInput" ref="searchString" class="t-self-stretch t-flex-expand t-p-0 t-text-lg t-text-base-tone placeholder:t-text-base-lighter">
+      <input type="text" v-model="searchString" @input="onInput" @blur="$v.searchString.$touch()" id="search" :placeholder="$t('Type what you are looking for...')" autocorrect="off" autocomplete="off" autofocus="true" data-test-id="SearchInput" ref="searchString" class="t-self-stretch t-flex-expand t-p-0 t-text-lg t-text-base-tone placeholder:t-text-base-lighter">
     </template>
     <template v-slot:top-right>
       <top-button icon="close" text="Close" @click.native="emptySearchInput" v-show="searchString.length > 0" />


### PR DESCRIPTION
* This is a workaround as Android-Chrome won't recognize changes on inputs v-model until space or enter is pressed. It's connected to the used keyboard (Gboard and others) which uses composition (e.g. underlining and autocomplete). It is considered incomplete until you either hit space (indicating ending the word) or explicitly selecting a suggestion.
  Source: https://github.com/vuejs/vue/issues/9777#issuecomment-478831263 & https://forum.vuejs.org/t/v-model-not-working-on-chrome-browser-on-android-device/36364
* Add `autocorrect="off"` & `autocomplete="off"` to search input