### PR TITLE
Clear cart first in `/order-success` page

### DIFF
--- a/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
+++ b/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
@@ -45,8 +45,8 @@ export default {
     }
   },
   async beforeMount () {
-    await this.onLogin()
     this.clearCart()
+    await this.onLogin()
   },
   watch: {
     /**


### PR DESCRIPTION
* Otherwise the old cart could remain if the `onLogin` action takes long or fails