### PR TITLE
Only call GTM `icmaa-*` mutation-events when they are not silenced

### DIFF
--- a/core/modules/cart/store/actions/itemActions.ts
+++ b/core/modules/cart/store/actions/itemActions.ts
@@ -102,7 +102,7 @@ const itemActions = {
     const product = payload.product || payload
     const { cartItem } = cartHooksExecutors.beforeRemoveFromCart({ cartItem: product })
 
-    commit(types.CART_DEL_ITEM, { product: cartItem, removeByParentSku })
+    commit(types.CART_DEL_ITEM, { product: cartItem, removeByParentSku, forceServerSilence: false })
 
     if (getters.isCartSyncEnabled && cartItem.server_item_id) {
       const diffLog = await dispatch('sync', { forceClientState: true })

--- a/core/modules/cart/store/actions/itemActions.ts
+++ b/core/modules/cart/store/actions/itemActions.ts
@@ -71,7 +71,8 @@ const itemActions = {
 
         if (status === 'ok' || status === 'volatile') {
           commit(types.CART_ADD_ITEM, {
-            product: { ...product, onlineStockCheckid: onlineCheckTaskId }
+            product: { ...product, onlineStockCheckid: onlineCheckTaskId },
+            forceServerSilence
           })
         }
         if (productIndex === (productsToAdd.length - 1) && (!getters.isCartSyncEnabled || forceServerSilence)) {

--- a/core/modules/cart/store/mutations.ts
+++ b/core/modules/cart/store/mutations.ts
@@ -34,7 +34,7 @@ const mutations: MutationTree<CartState> = {
   [types.CART_SET_TOTALS_SYNC] (state) {
     state.cartServerLastTotalsSyncDate = new Date().getTime()
   },
-  [types.CART_DEL_ITEM] (state, { product, removeByParentSku = true }) {
+  [types.CART_DEL_ITEM] (state, { product, removeByParentSku = true, forceServerSilence = true }) {
     EventBus.$emit('cart-before-delete', { items: state.cartItems })
     state.cartItems = state.cartItems.filter(p => !productsEquals(p, product) && (p.parentSku !== product.sku || removeByParentSku === false))
     EventBus.$emit('cart-after-delete', { items: state.cartItems })

--- a/core/modules/cart/store/mutations.ts
+++ b/core/modules/cart/store/mutations.ts
@@ -11,7 +11,7 @@ const mutations: MutationTree<CartState> = {
    * Add product to cart
    * @param {Object} product data format for products is described in /doc/ElasticSearch data formats.md
    */
-  [types.CART_ADD_ITEM] (state, { product }) {
+  [types.CART_ADD_ITEM] (state, { product, forceServerSilence }) {
     const record = state.cartItems.find(p => productsEquals(p, product))
     if (!record) {
       let item = {

--- a/core/modules/cart/test/unit/store/itemActions.spec.ts
+++ b/core/modules/cart/test/unit/store/itemActions.spec.ts
@@ -167,6 +167,7 @@ describe('Cart itemActions', () => {
 
   it('removes item from the cart', async () => {
     const product = { sku: 1, name: 'product1', server_item_id: 1, qty: 1 }
+    const forceServerSilence = false
 
     const contextMock = createContextMock({
       getters: {
@@ -175,7 +176,7 @@ describe('Cart itemActions', () => {
     })
 
     await (cartActions as any).removeItem(contextMock, { product })
-    expect(contextMock.commit).toBeCalledWith(types.CART_DEL_ITEM, { product, removeByParentSku: false })
+    expect(contextMock.commit).toBeCalledWith(types.CART_DEL_ITEM, { product, removeByParentSku: false, forceServerSilence })
     expect(contextMock.dispatch).toBeCalledWith('sync', { forceClientState: true })
   })
 })

--- a/core/modules/cart/test/unit/store/itemActions.spec.ts
+++ b/core/modules/cart/test/unit/store/itemActions.spec.ts
@@ -142,6 +142,7 @@ describe('Cart itemActions', () => {
   it('adds items to the cart', async () => {
     (validateProduct as jest.Mock).mockImplementation(() => [])
     const product = { sku: 1, name: 'product1', server_item_id: 1, qty: 1 }
+    const forceServerSilence = false
 
     const contextMock = createContextMock({
       getters: {
@@ -158,7 +159,7 @@ describe('Cart itemActions', () => {
       .mockImplementationOnce(() => Promise.resolve({ isEmpty: () => { return true } }))
 
     await (cartActions as any).addItems(contextMock, { productsToAdd: [product] })
-    expect(contextMock.commit).toBeCalledWith(types.CART_ADD_ITEM, { product: { ...product, onlineStockCheckid: 1 } })
+    expect(contextMock.commit).toBeCalledWith(types.CART_ADD_ITEM, { product: { ...product, onlineStockCheckid: 1 }, forceServerSilence })
     expect(contextMock.dispatch).toHaveBeenNthCalledWith(1, 'checkProductStatus', { product })
     expect(contextMock.dispatch).toHaveBeenNthCalledWith(2, 'create')
     expect(contextMock.dispatch).toHaveBeenNthCalledWith(3, 'sync', { forceClientState: true })

--- a/src/modules/icmaa-google-tag-manager/README.md
+++ b/src/modules/icmaa-google-tag-manager/README.md
@@ -76,7 +76,7 @@ Follow these steps to add a custom page-view type:
 We try to overwrite everything needed by extending the Vuex store. But some methods are not highjackable like that – this is a list of core changes.
 
 * We need specific page routes to contain meta fields to recognize the page-type by this field. We need this to deliver different data-layer objects for the GTM page-view event. Thats why we added these fields to the URL objects of `core/modules/url/helpers/transformUrl.ts`.
-* We added the `forceServerSilence` parameter to the `CART_ADD_ITEM` mutation and `cart/addItems` action to know when the commit is an user-interaction and when not. This is necessary to not trigger the `icmaa-add-to-cart` GTM event each time a item is added to cart by server (e.g. after login).
+* We added the `forceServerSilence` parameter to the `CART_ADD_ITEM`/`CART_DEL_ITEM` mutations and `cart/addItems`/`cart/removeItem` actions to know when the commit is an user-interaction and when not. This is necessary to not trigger the `icmaa-add-to-cart` GTM event each time a item is added to cart by server (e.g. after login).
 
 ## Config
 

--- a/src/modules/icmaa-google-tag-manager/README.md
+++ b/src/modules/icmaa-google-tag-manager/README.md
@@ -76,6 +76,7 @@ Follow these steps to add a custom page-view type:
 We try to overwrite everything needed by extending the Vuex store. But some methods are not highjackable like that – this is a list of core changes.
 
 * We need specific page routes to contain meta fields to recognize the page-type by this field. We need this to deliver different data-layer objects for the GTM page-view event. Thats why we added these fields to the URL objects of `core/modules/url/helpers/transformUrl.ts`.
+* We added the `forceServerSilence` parameter to the `CART_ADD_ITEM` mutation and `cart/addItems` action to know when the commit is an user-interaction and when not. This is necessary to not trigger the `icmaa-add-to-cart` GTM event each time a item is added to cart by server (e.g. after login).
 
 ## Config
 

--- a/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
@@ -39,6 +39,12 @@ export function afterRegistration () {
   }
 
   rootStore.subscribe(({ type, payload }) => {
+    if (payload.hasOwnProperty('forceServerSilence') &&
+      payload.forceServerSilence === true
+    ) {
+      return
+    }
+
     // Adding a product to a Shopping Cart
     if (type === 'cart/' + cartMutations.CART_ADD_ITEM) {
       GTM.trackEvent({

--- a/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
@@ -39,11 +39,7 @@ export function afterRegistration () {
   }
 
   rootStore.subscribe(({ type, payload }) => {
-    if (payload.hasOwnProperty('forceServerSilence') &&
-      payload.forceServerSilence === true
-    ) {
-      return
-    }
+    if (payload && payload.hasOwnProperty('forceServerSilence') && payload.forceServerSilence === true) return
 
     // Adding a product to a Shopping Cart
     if (type === 'cart/' + cartMutations.CART_ADD_ITEM) {


### PR DESCRIPTION
* We added the `forceServerSilence` parameter to the `CART_ADD_ITEM`/`CART_DEL_ITEM` mutations and `cart/addItems`/`cart/removeItem` actions to know when it is an user-interaction and when not