### PR TITLE
#213839 Clear cart before login when coming back from external-checkout

### DIFF
--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -33,10 +33,10 @@ const actions: ActionTree<CartState, RootState> = {
     commit(orgTypes.CART_LOAD_CART_SERVER_TOKEN, token)
     return dispatch('sync', { forceClientState, dryRun: !config.serverMergeByDefault, mergeQty: true })
   },
-  async removeCoupon ({ getters, dispatch, commit }) {
+  async removeCoupon ({ getters, dispatch, commit }, { sync = true }) {
     if (getters.canSyncTotals) {
       const { result } = await CartService.removeCoupon()
-      if (result) {
+      if (result && sync) {
         await dispatch('couponCallback')
 
         // 'getCurrentCartHash' has been changed (it's based on cart items data)

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -27,6 +27,7 @@ import fetchErrorHandler from 'icmaa-config/helpers/fetchResponseHandler'
 const actions: ActionTree<UserState, RootState> = {
   async startSessionWithToken ({ commit, dispatch }, token) {
     await dispatch('clearCurrentUser')
+    await dispatch('cart/clear', { }, { root: true })
     if (isServer) {
       return
     }


### PR DESCRIPTION
* Otherwise the old (same) quote will be merged with the new quote which is merged during login in external checkout. This would otherwise look like the product is added to cart twice.
* Also add `{ sync = true }` parameter to `cart/removeCoupon` action (as we had overwritten the original action).