### PR TITLE
#214664 Create custom event-hook for `icmaa-remove-from-cart`

### DIFF
--- a/core/modules/cart/store/actions/itemActions.ts
+++ b/core/modules/cart/store/actions/itemActions.ts
@@ -102,7 +102,7 @@ const itemActions = {
     const product = payload.product || payload
     const { cartItem } = cartHooksExecutors.beforeRemoveFromCart({ cartItem: product })
 
-    commit(types.CART_DEL_ITEM, { product: cartItem, removeByParentSku, forceServerSilence: false })
+    commit(types.CART_DEL_ITEM, { product: cartItem, removeByParentSku })
 
     if (getters.isCartSyncEnabled && cartItem.server_item_id) {
       const diffLog = await dispatch('sync', { forceClientState: true })

--- a/core/modules/cart/store/mutations.ts
+++ b/core/modules/cart/store/mutations.ts
@@ -34,7 +34,7 @@ const mutations: MutationTree<CartState> = {
   [types.CART_SET_TOTALS_SYNC] (state) {
     state.cartServerLastTotalsSyncDate = new Date().getTime()
   },
-  [types.CART_DEL_ITEM] (state, { product, removeByParentSku = true, forceServerSilence = true }) {
+  [types.CART_DEL_ITEM] (state, { product, removeByParentSku = true }) {
     EventBus.$emit('cart-before-delete', { items: state.cartItems })
     state.cartItems = state.cartItems.filter(p => !productsEquals(p, product) && (p.parentSku !== product.sku || removeByParentSku === false))
     EventBus.$emit('cart-after-delete', { items: state.cartItems })

--- a/core/modules/cart/test/unit/store/itemActions.spec.ts
+++ b/core/modules/cart/test/unit/store/itemActions.spec.ts
@@ -167,7 +167,6 @@ describe('Cart itemActions', () => {
 
   it('removes item from the cart', async () => {
     const product = { sku: 1, name: 'product1', server_item_id: 1, qty: 1 }
-    const forceServerSilence = false
 
     const contextMock = createContextMock({
       getters: {
@@ -176,7 +175,7 @@ describe('Cart itemActions', () => {
     })
 
     await (cartActions as any).removeItem(contextMock, { product })
-    expect(contextMock.commit).toBeCalledWith(types.CART_DEL_ITEM, { product, removeByParentSku: false, forceServerSilence })
+    expect(contextMock.commit).toBeCalledWith(types.CART_DEL_ITEM, { product, removeByParentSku: false })
     expect(contextMock.dispatch).toBeCalledWith('sync', { forceClientState: true })
   })
 })

--- a/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
+++ b/src/modules/icmaa-external-checkout/pages/ExternalSuccess.vue
@@ -8,9 +8,12 @@
       </div>
       <div v-if="lastOrder">
         {{ $t('Your order-number is:') }}
-        <router-link class="t-font-mono t-text-base-tone lg:t-pl-2" :to="localizedRoute(`/my-account/orders/${lastOrder.id}`)">
+        <router-link class="t-font-mono t-text-base-tone lg:t-pl-2" :to="localizedRoute(`/my-account/orders/${lastOrder.id}`)" v-if="isLoggedIn">
           #{{ lastOrder.increment_id }}
         </router-link>
+        <span class="t-font-mono t-text-base-tone lg:t-pl-2" v-else>
+          #{{ lastOrder.increment_id }}
+        </span>
       </div>
       <google-customer-review type="batch" />
       <google-customer-review type="popup" />

--- a/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
@@ -54,19 +54,6 @@ export function afterRegistration () {
       })
     }
 
-    // Removing a product from a Shopping Cart
-    if (type === 'cart/' + cartMutations.CART_DEL_ITEM) {
-      GTM.trackEvent({
-        event: 'icmaa-remove-from-cart',
-        ecommerce: {
-          currencyCode: currencyCode,
-          remove: {
-            products: [ getProduct(payload.product) ]
-          }
-        }
-      })
-    }
-
     // Adding a product to wishlist
     if (type === 'wishlist/' + wishlistMutations.WISH_ADD_ITEM) {
       GTM.trackEvent({
@@ -119,6 +106,18 @@ export function afterRegistration () {
     GTM.trackEvent({
       event: 'icmaa-on-product-list-filter',
       filter
+    })
+  })
+
+  EventHooks.removeProductFromCart(({ product }) => {
+    GTM.trackEvent({
+      event: 'icmaa-remove-from-cart',
+      ecommerce: {
+        currencyCode: currencyCode,
+        remove: {
+          products: [ getProduct(product) ]
+        }
+      }
     })
   })
 

--- a/src/modules/icmaa-google-tag-manager/hooks/index.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/index.ts
@@ -33,6 +33,11 @@ const {
 } = createListenerHook<{ filter: any }>()
 
 const {
+  hook: removeProductFromCartHook,
+  executor: removeProductFromCartExecutor
+} = createListenerHook<{ product: Product }>()
+
+const {
   hook: facebookLoginClickedHook,
   executor: facebookLoginClickedExecutor
 } = createListenerHook<{ status: string }>()
@@ -44,6 +49,7 @@ const IcmaaGoogleTagManagerExecutors = {
   searchResultVisited: searchResultVisitedExecutor,
   openProductListFilterSidebar: openProductListFilterSidebarExecutor,
   onProductListFilter: onProductListFilterExecutor,
+  removeProductFromCart: removeProductFromCartExecutor,
   facebookLoginClicked: facebookLoginClickedExecutor
 }
 
@@ -54,6 +60,7 @@ const IcmaaGoogleTagManager = {
   searchResultVisited: searchResultVisitedHook,
   openProductListFilterSidebar: openProductListFilterSidebarHook,
   onProductListFilter: onProductListFilterHook,
+  removeProductFromCart: removeProductFromCartHook,
   facebookLoginClicked: facebookLoginClickedHook
 }
 

--- a/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
@@ -81,6 +81,7 @@ import { mapGetters } from 'vuex'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { productThumbnailPath } from '@vue-storefront/core/helpers'
 import { formatProductLink } from 'icmaa-url/helpers'
+import { IcmaaGoogleTagManagerExecutors } from 'icmaa-google-tag-manager/hooks'
 import Product from '@vue-storefront/core/compatibility/components/blocks/Microcart/Product'
 import ProductNameMixin from 'icmaa-catalog/mixins/ProductNameMixin'
 import ProductImage from 'theme/components/core/ProductImage'
@@ -204,7 +205,8 @@ export default {
         .then(() => { this.loading = false })
     },
     async removeFromCart () {
-      this.$store.dispatch('cart/removeItem', { product: this.product })
+      await this.$store.dispatch('cart/removeItem', { product: this.product })
+      IcmaaGoogleTagManagerExecutors.removeProductFromCart({ product: this.product })
     }
   }
 }


### PR DESCRIPTION
* We used to check `forceServerSilence` while we traced any commit for this action but there are some `sync/merge` actions that are using this action as well and therefore also will trigger the GTM event.
* Now we just track the click on the button in the cart and need to consider to re-trigger it when we add more ways to remove items from cart.
* We also undone our changes on the `cart/removeItem` action and the `CART_DEL_ITEM` commit method from the recent changes (dce7d672c2b08f8f4b7eaea0a389e6ce5690b972).