### PR TITLE
#214316 Bugfix for wrong cart qty after coming back from external-checkout

### DIFF
--- a/core/modules/cart/store/actions/mergeActions.ts
+++ b/core/modules/cart/store/actions/mergeActions.ts
@@ -156,7 +156,7 @@ const mergeActions = {
     const productToAdd = await dispatch('getProductVariant', { serverItem })
 
     if (productToAdd) {
-      dispatch('addItem', { productToAdd, forceServerSilence: true })
+      await dispatch('addItem', { productToAdd, forceServerSilence: true })
       Logger.debug('Product variant for given serverItem has not found', 'cart', serverItem)()
     }
 

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -73,7 +73,7 @@ const synchronizeActions = {
       await dispatch('connect', { guestCart: true })
     }
 
-    Logger.error(result, 'cart')
+    Logger.error('Error while `cart/sync` action:', 'cart', result)()
     cartHooksExecutors.afterSync(result)
     commit(types.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
     return createDiffLog()

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -27,12 +27,6 @@ const actions: ActionTree<CartState, RootState> = {
       await dispatch('applyCoupon', coupon)
     }
   },
-  async reconnect ({ dispatch, commit }, { token, forceClientState = false }) {
-    Logger.info('Reconnect quote with:', 'cart', token)()
-
-    commit(orgTypes.CART_LOAD_CART_SERVER_TOKEN, token)
-    return dispatch('sync', { forceClientState, dryRun: !config.serverMergeByDefault, mergeQty: true })
-  },
   async removeCoupon ({ getters, dispatch, commit }, { sync = true } = {}) {
     if (getters.canSyncTotals) {
       const { result } = await CartService.removeCoupon()

--- a/src/modules/icmaa-external-checkout/index.ts
+++ b/src/modules/icmaa-external-checkout/index.ts
@@ -24,40 +24,31 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
       Vue.use(VueCookies)
     })
 
-    const getCookies = (): { customerToken: string, quoteToken: string, lastOrderToken: string } => {
+    const getCookies = (): { customerToken: string, lastOrderToken: string } => {
       return {
         customerToken: Vue.$cookies.get('vsf_token_customer'),
-        quoteToken: Vue.$cookies.get('vsf_token_quote'),
         lastOrderToken: Vue.$cookies.get('vsf_token_lastorder')
       }
     }
 
     EventBus.$on('session-after-started', async () => {
-      const { customerToken, quoteToken, lastOrderToken } = getCookies()
+      const { customerToken, lastOrderToken } = getCookies()
 
-      if (store.getters['user/isLoggedIn'] && (customerToken || quoteToken || lastOrderToken)) {
+      if (store.getters['user/isLoggedIn'] && (customerToken || lastOrderToken)) {
         Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
-        Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
         Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
       }
     })
 
     EventBus.$on('session-after-nonauthorized', async () => {
-      const { customerToken, quoteToken, lastOrderToken } = getCookies()
+      const { customerToken, lastOrderToken } = getCookies()
 
-      if (!store.getters['user/isLoggedIn'] && (customerToken || quoteToken || lastOrderToken)) {
+      if (!store.getters['user/isLoggedIn'] && (customerToken || lastOrderToken)) {
         if (customerToken) {
           Logger.info('Customer token found in cookie – try to login:', 'external-checkout', customerToken)()
-          store.dispatch('user/startSessionWithToken', customerToken).then(() => {
+          store.dispatch('user/startSessionWithToken', { token: customerToken }).then(() => {
             Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
             Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
-          })
-        }
-
-        if (quoteToken) {
-          Logger.info('Quote token found in cookie – try to reconnect with:', 'external-checkout', quoteToken)()
-          store.dispatch('cart/reconnect', { token: quoteToken }).then(() => {
-            Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
           })
         }
 
@@ -97,7 +88,6 @@ export const IcmaaExternalCheckoutModule: StorefrontModule = function ({ router,
       }
 
       Vue.$cookies.remove('vsf_token_customer', undefined, getCookieHostname())
-      Vue.$cookies.remove('vsf_token_quote', undefined, getCookieHostname())
       Vue.$cookies.remove('vsf_token_lastorder', undefined, getCookieHostname())
     })
   }

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -25,12 +25,13 @@ import isEmpty from 'lodash-es/isEmpty'
 import fetchErrorHandler from 'icmaa-config/helpers/fetchResponseHandler'
 
 const actions: ActionTree<UserState, RootState> = {
-  async startSessionWithToken ({ commit, dispatch }, token) {
-    await dispatch('clearCurrentUser')
-    await dispatch('cart/clear', { }, { root: true })
+  async startSessionWithToken ({ commit, dispatch }, { token }) {
     if (isServer) {
       return
     }
+
+    await dispatch('cart/clear', { sync: false }, { root: true })
+    await dispatch('clearCurrentUser')
 
     commit(userTypes.USER_START_SESSION)
 

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -30,7 +30,6 @@ const actions: ActionTree<UserState, RootState> = {
       return
     }
 
-    await dispatch('cart/clear', { sync: false }, { root: true })
     await dispatch('clearCurrentUser')
 
     commit(userTypes.USER_START_SESSION)

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -30,6 +30,7 @@ const actions: ActionTree<UserState, RootState> = {
       return
     }
 
+    await dispatch('cart/clear', { sync: false }, { root: true })
     await dispatch('clearCurrentUser')
 
     commit(userTypes.USER_START_SESSION)


### PR DESCRIPTION
This behavior is caused by multiple problems:
* We didn't clear the cart before we reassign the session – this leads into a merge of the same cart into the existing one after the generic login in the VSF. I also disabled the `sync` parameter for the `cart/clear` action in `user/startSessionWithToken` as we don't need it and it might ends in conflicts with congruent requests.
* I removed the `vsf_token_quote ` cookie logic as we don't need this anymore. The user is logged in if the  `vsf_token_customer` cookie is set and will load the quote after login.
* Prevent a `TypeError: result.forEach is not a function` error notification on add-to-cart actions when the request returns an error. This was caused by a custom `cartHooks.beforeSync` hook and its `cart/updateFreeCartItems` action which might receive as error-message-string instead an array.
* Bugfix for `cart/mergeServerItem` method which adds cart-items asynchronously. When you logged in inside the external-checkout and then went back to the VSF, the cart is first emptied and then merged correctly into another. But at the end the wrong `cartItemsHash`  is saved to the local-storage. This causes that, at the next reload, the cart is merged with itself because it thinks `isSyncRequired` and `mergeQty` in the `cart/connect` action are `true`. The wrong `cartItemsHash` is saved because the VSF wouldn't wait for the async `addItem` action in `mergeServerItem`.

It's connected with the problems of #480