### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.1
+      - uses: actions/setup-node@v1
         with:
           node-version: '13.x'
 
@@ -30,12 +30,12 @@ jobs:
 
       - name: Get repository name, and branch name
         run: |
-           echo ::set-env name=APP::$(echo ${GITHUB_REPOSITORY##*/})
-           echo ::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})
+          echo "APP=$(echo ${GITHUB_REPOSITORY##*/})" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
       - name: Get environment by branch
         run: |
-          echo ::set-env name=ENV::$(if [ ${{ env.BRANCH_NAME }} = "master" ]; then echo "production"; else echo "test"; fi)
+          echo "ENV=$(if [ ${{ env.BRANCH_NAME }} = "master" ]; then echo "production"; else echo "test"; fi)" >> $GITHUB_ENV
 
       - name: Checkout "icmaa/shop-workspace" repo
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.1
+      - uses: actions/setup-node@v1
         with:
           node-version: '13.x'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
           yarn pm2 start ecosystem.ci.json
 
       - name: Cypress run
-        uses: cypress-io/github-action@v1.16.1
+        uses: cypress-io/github-action@v2
         timeout-minutes: 5
         with:
           working-directory: src/themes/icmaa-imp/test/e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.1
+      - uses: actions/setup-node@v1
         with:
           node-version: '13.x'
 
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.1
+      - uses: actions/setup-node@v1
         with:
           node-version: '13.x'
 


### PR DESCRIPTION
* There was an update in GitHub-Actions which needs us to change some things: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/