### PR TITLE
#214982 & #215028 Add JWT expiration-time and improve session-health

### DIFF
--- a/core/data-resolver/UserService.ts
+++ b/core/data-resolver/UserService.ts
@@ -66,9 +66,10 @@ const updateProfile = async (userProfile: UserProfile, actionName: string): Prom
     callback_event: `store:${actionName}`
   })
 
-const getProfile = async () =>
+const getProfile = async (silent: boolean = false) =>
   TaskQueue.execute({
     url: processLocalizedURLAddress(getApiEndpointUrl(config.users, 'me_endpoint')),
+    silent,
     payload: {
       method: 'GET',
       mode: 'cors',

--- a/core/data-resolver/types/DataResolver.d.ts
+++ b/core/data-resolver/types/DataResolver.d.ts
@@ -93,7 +93,7 @@ declare namespace DataResolver {
     login: (username: string, password: string) => Promise<Task>,
     register: (customer: Customer, pssword: string) => Promise<Task>,
     updateProfile: (userProfile: UserProfile, actionName: string) => Promise<Task>,
-    getProfile: () => Promise<Task>,
+    getProfile: (silent?: boolean) => Promise<Task>,
     getOrdersHistory: (pageSize?: number, currentPage?: number) => Promise<Task>,
     changePassword: (passwordData: PasswordData) => Promise<Task>,
     refreshToken: (refreshToken: string) => Promise<string>

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -162,7 +162,7 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
         }
       }
 
-      Logger.debug('Response for: ' + task.task_id + ' = ' + JSON.stringify(jsonResponse.result), 'sync')()
+      Logger.debug('Response for: ' + task.task_id, 'sync', JSON.stringify(jsonResponse.result))()
       task.transmited = true
       task.transmited_at = new Date()
       task.result = jsonResponse.result
@@ -217,8 +217,8 @@ export function registerSyncTaskProcessor () {
       const currentCartToken = rootStore.getters['cart/getCartToken']
 
       const fetchQueue = []
-      Logger.debug('Current User token = ' + currentUserToken)()
-      Logger.debug('Current Cart token = ' + currentCartToken)()
+      Logger.debug('Current User token:', 'sync', currentUserToken)()
+      Logger.debug('Current Cart token:', 'sync', currentCartToken)()
       syncTaskCollection.iterate((task, id) => {
         if (task && !task.transmited && !mutex[id]) { // not sent to the server yet
           mutex[id] = true // mark this task as being processed

--- a/core/modules/cart/store/actions/connectActions.ts
+++ b/core/modules/cart/store/actions/connectActions.ts
@@ -34,7 +34,7 @@ const connectActions = {
       await dispatch('removeCoupon', { sync: false })
     }
 
-    await dispatch('connect', { guestCart: false, mergeQty: false })
+    await dispatch('connect', { guestCart: false, mergeQty: true })
 
     if (coupon) {
       await dispatch('applyCoupon', coupon)

--- a/core/modules/cart/store/actions/connectActions.ts
+++ b/core/modules/cart/store/actions/connectActions.ts
@@ -34,7 +34,7 @@ const connectActions = {
       await dispatch('removeCoupon', { sync: false })
     }
 
-    await dispatch('connect', { guestCart: false, mergeQty: true })
+    await dispatch('connect', { guestCart: false, mergeQty: false })
 
     if (coupon) {
       await dispatch('applyCoupon', coupon)

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -16,7 +16,7 @@ const synchronizeActions = {
     dispatch('setDefaultCheckoutMethods')
     const storedItems = await StorageManager.get('cart').getItem('current-cart')
     commit(types.CART_LOAD_CART, storedItems)
-    dispatch('synchronizeCart', { forceClientState })
+    await dispatch('synchronizeCart', { forceClientState })
 
     cartHooksExecutors.afterLoad(storedItems)
   },
@@ -38,9 +38,9 @@ const synchronizeActions = {
       commit(types.CART_LOAD_CART_SERVER_TOKEN, token)
       Logger.info('Cart token received from cache.', 'cache', token)()
       Logger.info('Syncing cart with the server.', 'cart')()
-      dispatch('sync', { forceClientState, dryRun: !serverMergeByDefault })
+      return dispatch('sync', { forceClientState, dryRun: !serverMergeByDefault })
     }
-    await dispatch('create')
+    return dispatch('create')
   },
   /** @deprecated backward compatibility only */
   async serverPull ({ dispatch }, { forceClientState = false, dryRun = false }) {

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -116,7 +116,7 @@ const actions: ActionTree<UserState, RootState> = {
       commit(types.USER_INFO_LOADED, currentUser)
       await dispatch('setUserGroup', currentUser)
       EventBus.$emit('user-after-loggedin', currentUser)
-      dispatch('cart/authorize', {}, { root: true })
+      await dispatch('cart/authorize', {}, { root: true })
 
       return currentUser
     }

--- a/src/modules/icmaa-cart/README.md
+++ b/src/modules/icmaa-cart/README.md
@@ -1,8 +1,14 @@
 # `icmaa-cart` module
 
-Add our custom functionality for the original `cart` module.
+Add our custom functionality for the original `cart` module:
+* Overwrites the `cart/getCoupon` store getter to evaluate if a `ugiftcert` (Unirgy-GiftCert) is applied to cart.
+* Add functionallity for JWT expiration.
 
-Overwrites the `cart/getCoupon` store getter to evaluate if a `ugiftcert` (Unirgy-GiftCert) is applied to cart.
+## Core changes
+
+We try to overwrite everything needed by extending the Vuex store. But some methods are not highjackable like that – this is a list of core changes.
+
+* In the `core/modules/cart/store/actions/synchronizeActions.ts` we added some `async`/`await` logic to be sure to wait for specific requests. We added one for the `cart/synchronizeCart` action inside the `cart/load` action. We also prevent `cart/create` inside the `cart/synchronizeCart` action if a token is already found (just `cart/sync` instead).
 
 ## Todo
 

--- a/src/modules/icmaa-cart/helpers/index.ts
+++ b/src/modules/icmaa-cart/helpers/index.ts
@@ -1,0 +1,5 @@
+import notifications from './notifications'
+
+export {
+  notifications
+}

--- a/src/modules/icmaa-cart/helpers/notifications.ts
+++ b/src/modules/icmaa-cart/helpers/notifications.ts
@@ -8,7 +8,8 @@ const errorMsgMap = {
   'Your cart has been expired.': createNotification('Sorry, but your cart has been expired. Please try again.'),
   'Your session has been expired.': createNotification('Sorry, but your login has been expired. Please try to login again.'),
   'User is not authroized to access quote:': createNotification('Sorry, but your login has been expired. Please try to login again.'),
-  'No quote found for token:': createNotification('Sorry, but there was an error with your cart. Please try again.')
+  'No quote found for token:': createNotification('Sorry, but there was an error with your cart. Please try again.'),
+  'User is not authroized to access': createNotification('Sorry, your session is not authorized – maybe it has been expired. Please try to login again.')
 }
 
 const isKnownError = (message: string): boolean => {

--- a/src/modules/icmaa-cart/helpers/notifications.ts
+++ b/src/modules/icmaa-cart/helpers/notifications.ts
@@ -11,6 +11,11 @@ const errorMsgMap = {
   'No quote found for token:': createNotification('Sorry, but there was an error with your cart. Please try again.')
 }
 
+const isKnownError = (message: string): boolean => {
+  const errorMsgs = Object.keys(errorMsgMap)
+  return (errorMsgs.includes(message) || !!errorMsgs.find(m => m.startsWith(message)))
+}
+
 const getNotificationByResponse = (message: string) => {
   const errorMsgs = Object.keys(errorMsgMap)
   if (errorMsgs.includes(message)) {
@@ -23,5 +28,6 @@ const getNotificationByResponse = (message: string) => {
 }
 
 export default {
-  getNotificationByResponse
+  getNotificationByResponse,
+  isKnownError
 }

--- a/src/modules/icmaa-cart/helpers/notifications.ts
+++ b/src/modules/icmaa-cart/helpers/notifications.ts
@@ -1,0 +1,27 @@
+import i18n from '@vue-storefront/i18n'
+import { notifications } from '@vue-storefront/core/modules/cart/helpers'
+
+const createNotification = (message: string, type: string = 'error') =>
+  notifications.createNotification({ type, message: i18n.t(message) })
+
+const errorMsgMap = {
+  'Your cart has been expired.': createNotification('Sorry, but your cart has been expired. Please try again.'),
+  'Your session has been expired.': createNotification('Sorry, but your login has been expired. Please try to login again.'),
+  'User is not authroized to access quote:': createNotification('Sorry, but your login has been expired. Please try to login again.'),
+  'No quote found for token:': createNotification('Sorry, but there was an error with your cart. Please try again.')
+}
+
+const getNotificationByResponse = (message: string) => {
+  const errorMsgs = Object.keys(errorMsgMap)
+  if (errorMsgs.includes(message)) {
+    return errorMsgMap[message]
+  } else if (errorMsgs.find(m => m.startsWith(message))) {
+    return errorMsgMap[errorMsgs.find(m => m.startsWith(message))]
+  }
+
+  return createNotification(message)
+}
+
+export default {
+  getNotificationByResponse
+}

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -5,6 +5,7 @@ import { CartService } from '@vue-storefront/core/data-resolver'
 import { cartHooksExecutors } from '@vue-storefront/core/modules/cart/hooks'
 import { createDiffLog, productsEquals } from '@vue-storefront/core/modules/cart/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { notifications } from '../helpers'
 import config from 'config'
 import * as types from '../store/mutation-types'
 import * as orgTypes from '@vue-storefront/core/modules/cart/store/mutation-types'
@@ -69,7 +70,12 @@ const actions: ActionTree<CartState, RootState> = {
     await dispatch('clear', { sync: false })
       .then(() => { Logger.log('Cart has been cleared.', 'cart')() })
 
-    return createDiffLog()
+    const errorDiffLog = createDiffLog()
+
+    const errorMessage = notifications.getNotificationByResponse(result)
+    errorDiffLog.pushNotification(errorMessage)
+
+    return errorDiffLog
   },
   async removeCoupon ({ getters, dispatch, commit }, { sync = true } = {}) {
     if (getters.canSyncTotals) {

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -3,7 +3,9 @@ import RootState from '@vue-storefront/core/types/RootState'
 import CartState from '@vue-storefront/core/modules/cart/types/CartState'
 import { CartService } from '@vue-storefront/core/data-resolver'
 import { cartHooksExecutors } from '@vue-storefront/core/modules/cart/hooks'
-import { productsEquals } from '@vue-storefront/core/modules/cart/helpers'
+import { createDiffLog, productsEquals } from '@vue-storefront/core/modules/cart/helpers'
+import { Logger } from '@vue-storefront/core/lib/logger'
+import config from 'config'
 import * as types from '../store/mutation-types'
 import * as orgTypes from '@vue-storefront/core/modules/cart/store/mutation-types'
 
@@ -25,6 +27,46 @@ const actions: ActionTree<CartState, RootState> = {
     if (coupon) {
       await dispatch('applyCoupon', coupon)
     }
+  },
+  /**
+   * Things we changed:
+   * * Update the cart-token after `CartService.getItems()` to extend JWT lifetime on each pull.
+   */
+  async sync ({ getters, rootGetters, commit, dispatch }, { forceClientState = false, dryRun = false, mergeQty = false, forceSync = false }) {
+    const shouldUpdateClientState = rootGetters['checkout/isUserInCheckout'] || forceClientState
+    const { getCartItems, canUpdateMethods, isSyncRequired, bypassCounter } = getters
+    if ((!canUpdateMethods || !isSyncRequired) && !forceSync) return createDiffLog()
+    commit(orgTypes.CART_SET_SYNC)
+    const { result, resultCode } = await CartService.getItems()
+    const { serverItems, clientItems } = cartHooksExecutors.beforeSync({ clientItems: getCartItems, serverItems: result.items })
+
+    if (resultCode === 200) {
+      if (result.token) {
+        Logger.log('Server cart token updated.', 'cart', result.token)()
+        commit(orgTypes.CART_LOAD_CART_SERVER_TOKEN, result.token)
+      }
+
+      const diffLog = await dispatch('merge', {
+        dryRun,
+        serverItems,
+        clientItems,
+        forceClientState: shouldUpdateClientState,
+        mergeQty
+      })
+      cartHooksExecutors.afterSync(diffLog)
+      return diffLog
+    }
+
+    if (bypassCounter < config.queues.maxCartBypassAttempts) {
+      Logger.log('Bypassing with guest cart' + bypassCounter, 'cart')()
+      commit(orgTypes.CART_UPDATE_BYPASS_COUNTER, { counter: 1 })
+      await dispatch('connect', { guestCart: true })
+    }
+
+    Logger.error('Error while `cart/sync` action:', 'cart', result)()
+    cartHooksExecutors.afterSync(result)
+    commit(orgTypes.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
+    return createDiffLog()
   },
   async removeCoupon ({ getters, dispatch, commit }, { sync = true } = {}) {
     if (getters.canSyncTotals) {

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -65,7 +65,10 @@ const actions: ActionTree<CartState, RootState> = {
 
     Logger.error('Error while `cart/sync` action:', 'cart', result)()
     cartHooksExecutors.afterSync(result)
-    commit(orgTypes.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
+
+    await dispatch('clear', { sync: false })
+      .then(() => { Logger.log('Cart has been cleared.', 'cart')() })
+
     return createDiffLog()
   },
   async removeCoupon ({ getters, dispatch, commit }, { sync = true } = {}) {

--- a/src/modules/icmaa-cart/store/actions.ts
+++ b/src/modules/icmaa-cart/store/actions.ts
@@ -64,7 +64,6 @@ const actions: ActionTree<CartState, RootState> = {
       await dispatch('connect', { guestCart: true })
     }
 
-    Logger.error('Error while `cart/sync` action:', 'cart', result)()
     cartHooksExecutors.afterSync(result)
 
     await dispatch('clear', { sync: false })
@@ -74,6 +73,9 @@ const actions: ActionTree<CartState, RootState> = {
 
     const errorMessage = notifications.getNotificationByResponse(result)
     errorDiffLog.pushNotification(errorMessage)
+
+    const logMessageType = notifications.isKnownError(result) ? 'warn' : 'error'
+    Logger[logMessageType]('Error while `cart/sync` action:', 'cart', result)()
 
     return errorDiffLog
   },

--- a/src/modules/icmaa-cart/store/getters.ts
+++ b/src/modules/icmaa-cart/store/getters.ts
@@ -2,8 +2,14 @@ import { GetterTree } from 'vuex'
 import RootState from '@vue-storefront/core/types/RootState'
 import CartState from '../types/CartState'
 import AppliedCoupon from '@vue-storefront/core/modules/cart/types/AppliedCoupon'
+import { calcItemsHmac } from '@vue-storefront/core/helpers'
 
 const getters: GetterTree<CartState, RootState> = {
+  /**
+   * We are now adding the cart-id-hash to the items, this way we don't need the server-cart-token anymore.
+   * The server-cart-token won't work as unique cart-hash anymore because it changes on each `cart/pull`.
+   */
+  getCurrentCartHash: state => calcItemsHmac(state.cartItems, ''),
   getCoupon: ({ platformTotals }): AppliedCoupon | false => {
     if (!platformTotals) {
       return false

--- a/src/modules/icmaa-cart/store/index.ts
+++ b/src/modules/icmaa-cart/store/index.ts
@@ -4,7 +4,9 @@ import mutations from './mutations'
 import actions from './actions'
 import CartState from '../types/CartState'
 
-let extendState = { freeCartItems: [] }
+let extendState = {
+  freeCartItems: []
+}
 
 export const IcmaaExtendedCartStore: Module<CartState, any> = {
   state: extendState as CartState,

--- a/src/modules/icmaa-user/README.md
+++ b/src/modules/icmaa-user/README.md
@@ -3,6 +3,7 @@
 * Extend the `user` module and add `customercluster` store.
 * Add Facebook login action to store and configs to `local.json`.
 * Add debug toolbar to quickly switch the cluster for debugging.
+* Add functionallity for JWT expiration.
 
 ## Configs
 
@@ -25,31 +26,11 @@ You need to add the following config to the `config/local.json`:
   ...
 ```
 
-## Debugging toolbar
+## Core changes
 
-To include the toolbar on a page you need it, just include it as a component like:
+We try to overwrite everything needed by extending the Vuex store. But some methods are not highjackable like that – this is a list of core changes.
 
-```
-<template>
-  <div>
-    ...
-    <cluster-debug />
-  </div>
-</template>
-
-<script>
-...
-import ClusterDebug from 'icmaa-user/components/Cluster/Debug'
-
-export default {
-  ...
-  components: {
-    ClusterDebug
-  },
-  ...
-}
-</script>
-```
+* We added an `await` to the `cart/authorize` action inside the `restoreCurrentUserFromCache` action in `core/modules/user/store/actions.ts` to be sure to wait for a valid cart.
 
 ## Todo
 

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -55,8 +55,6 @@ const actions: ActionTree<UserState, RootState> = {
   async refreshUserProfile ({ commit, dispatch }, { resolvedFromCache }) {
     const resp = await UserService.getProfile(true)
 
-    console.error(resp)
-
     if (resp.resultCode === 200) {
       commit(userTypes.USER_INFO_LOADED, resp.result) // this also stores the current user to localForage
       await dispatch('setUserGroup', resp.result)

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -18,6 +18,7 @@ import asyncForEach from 'icmaa-config/helpers/asyncForEach'
 
 import getApiEndpointUrl from '@vue-storefront/core/helpers/getApiEndpointUrl'
 import { processLocalizedURLAddress } from '@vue-storefront/core/helpers'
+import { notifications } from 'icmaa-cart/helpers'
 
 import config, { entities } from 'config'
 import fetch from 'isomorphic-fetch'
@@ -70,6 +71,10 @@ const actions: ActionTree<UserState, RootState> = {
         return resp
       }
     } else {
+      if (!notifications.isKnownError(resp.result)) {
+        Logger.error('Error while refreshing user:', 'user', resp.result)()
+      }
+
       await dispatch('logout', { silent: true })
     }
   },

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -53,18 +53,19 @@ const actions: ActionTree<UserState, RootState> = {
    * @param any param1
    */
   async refreshUserProfile ({ commit, dispatch }, { resolvedFromCache }) {
-    const resp = await UserService.getProfile()
+    const resp = await UserService.getProfile(true)
+
+    console.error(resp)
 
     if (resp.resultCode === 200) {
       commit(userTypes.USER_INFO_LOADED, resp.result) // this also stores the current user to localForage
       await dispatch('setUserGroup', resp.result)
-    }
 
-    if (resp.resultCode === 200) {
       if (resp.result.token) {
         Logger.log('User token was updated.', 'user', resp.result.token)()
         commit(userTypes.USER_TOKEN_CHANGED, { newToken: resp.result.token })
       }
+
       if (!resolvedFromCache) {
         EventBus.$emit('user-after-loggedin', resp.result)
         await dispatch('cart/authorize', {}, { root: true })

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -44,12 +44,43 @@ const actions: ActionTree<UserState, RootState> = {
 
     EventBus.$emit('session-after-started')
   },
+  /**
+   * Copy of original – changes:
+   * * Write updated user-token to store after profile is refreshed to extend JWT lifetime on each pull.
+   * * Logout if 500er response is returned from '/me' request.
+   *
+   * @param any param0
+   * @param any param1
+   */
+  async refreshUserProfile ({ commit, dispatch }, { resolvedFromCache }) {
+    const resp = await UserService.getProfile()
+
+    if (resp.resultCode === 200) {
+      commit(userTypes.USER_INFO_LOADED, resp.result) // this also stores the current user to localForage
+      await dispatch('setUserGroup', resp.result)
+    }
+
+    if (resp.resultCode === 200) {
+      if (resp.result.token) {
+        Logger.log('User token was updated.', 'user', resp.result.token)()
+        commit(userTypes.USER_TOKEN_CHANGED, { newToken: resp.result.token })
+      }
+      if (!resolvedFromCache) {
+        EventBus.$emit('user-after-loggedin', resp.result)
+        await dispatch('cart/authorize', {}, { root: true })
+        return resp
+      }
+    } else {
+      await dispatch('logout', { silent: true })
+    }
+  },
+  /**
+   * Copy of original – changes:
+   * * The original method now uses the `queue` (instead `execute`) to update the profile.
+   *   This leads to the problem that we can't trigger the user interaction as we want using a promise chain.
+   *   I rebuild the `UserService.updateProfile` method using `execute` to make it work again.
+   */
   async update ({ dispatch }, profile: UserProfile): Promise<Task> {
-    /**
-     * The original method now uses the `queue` (instead `execute`) to update the profile.
-     * This leads to the problem that we can't trigger the user interaction as we want using a promise chain.
-     * I rebuild the `UserService.updateProfile` method using `execute` to make it work again.
-     */
     return TaskQueue.execute({
       url: processLocalizedURLAddress(getApiEndpointUrl(config.users, 'me_endpoint')),
       payload: {

--- a/src/themes/icmaa-imp/components/core/blocks/Auth/Register.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Auth/Register.vue
@@ -240,7 +240,7 @@ export default {
         lastname: this.lastName,
         dob: this.dob,
         gender: this.gender,
-        cluster: this.cluster || '',
+        cluster: this.cluster || null,
         newsletter: this.newsletter
       }
 

--- a/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
@@ -202,11 +202,22 @@ export default {
     async updateQty (qty) {
       this.loading = true
       return this.$store.dispatch('cart/updateQuantity', { product: this.product, qty })
-        .then(() => { this.loading = false })
+        .then((diffLog) => {
+          diffLog.clientNotifications.forEach(notification => {
+            if (notification.type === 'error') {
+              this.notifyUser(notification)
+            }
+          })
+
+          this.loading = false
+        })
     },
     async removeFromCart () {
       await this.$store.dispatch('cart/removeItem', { product: this.product })
       IcmaaGoogleTagManagerExecutors.removeProductFromCart({ product: this.product })
+    },
+    notifyUser (notificationData) {
+      this.$store.dispatch('notification/spawnNotification', notificationData)
     }
   }
 }

--- a/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
@@ -57,7 +57,7 @@ export default {
       }
     },
     notifyUser (notificationData) {
-      this.$store.dispatch('notification/spawnNotification', notificationData, { root: true })
+      this.$store.dispatch('notification/spawnNotification', notificationData)
     },
     continueShopping (toCheckout = false) {
       this.$store.dispatch('ui/closeAll')

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -109,7 +109,7 @@ export default {
         }
 
         // Set defaults to fulfill JSON scheme of API
-        const defaults = { dob: null, gender: '', cluster: '' }
+        const defaults = { dob: null, gender: '', cluster: null }
         const customer = Object.assign(defaults, updatedData)
 
         await this.$store.dispatch('user/update', { customer })


### PR DESCRIPTION
* Add support for new JWT expiration-time (we needed to overwrite a few core actions):
  * I changed the `cart/getCurrentCartHash` getter as we don't need to create the cart-items-hash using the cart JWT anymore as this again is updated on each `cart/sync`. This would otherwise lead into a constant update of the cart because the `getCurrentCartHash` is changing. To be sure to check for the correct quote we added to quote-id into each product in the item payload of the Magento VSF bridge pull action.
  * I refactored the `cart/sync` action to update the cart JWT on each `sync` action to extend the lifetime of the JWT or delete the current cart if it isn't valid anymore.
  * I also refactored the `user/refreshUserProfile` action to update the customer JWT on each `me` action to extend the lifetime or logout the customer if the JWT is expired.
  * The `UserService.getProfile()` method has now a parameter to silent the API request to prevent notification on error.
* Added reasonable notifications when cart expires or errors happen
* Add some `async/await` fixes to core to assure correct timing during add-to-cart- and sync-routine
* Add more verbose logging for `core/lib/sync/task.ts`

Related tickets: TCK-214982 & TCK-215028

See PR icmaa/magento/pull/1154 for changes in Magento