### PR TITLE
Hotfix for fetch-request payload

### DIFF
--- a/src/modules/icmaa-newsletter/data-resolver/NewsletterService.ts
+++ b/src/modules/icmaa-newsletter/data-resolver/NewsletterService.ts
@@ -2,20 +2,12 @@ import { processLocalizedURLAddress } from '@vue-storefront/core/helpers'
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import Task from '@vue-storefront/core/lib/sync/types/Task'
 import config from 'config'
-import { NewsletterVoucher } from '../types/NewsletterState'
-
-const headers = {
-  'Accept': 'application/json, text/plain, */*',
-  'Content-Type': 'application/json'
-}
 
 const getVoucher = async (options: { email: string, rule: number }): Promise<Task> =>
   TaskQueue.execute({
     url: processLocalizedURLAddress(config.newsletter.endpoint_voucher.default),
     payload: {
       method: 'POST',
-      mode: 'cors',
-      headers,
       body: JSON.stringify(options)
     },
     silent: true
@@ -26,8 +18,6 @@ const getBirthdayVoucher = async (options: { email: string }): Promise<Task> =>
     url: processLocalizedURLAddress(config.newsletter.endpoint_voucher.birthday),
     payload: {
       method: 'POST',
-      mode: 'cors',
-      headers,
       body: JSON.stringify(options)
     },
     silent: true

--- a/src/modules/icmaa-user/data-resolver/UserService.ts
+++ b/src/modules/icmaa-user/data-resolver/UserService.ts
@@ -4,21 +4,11 @@ import Task from '@vue-storefront/core/lib/sync/types/Task'
 import config from 'config'
 import getApiEndpointUrl from '@vue-storefront/core/helpers/getApiEndpointUrl'
 
-const headers = {
-  'Accept': 'application/json, text/plain, */*',
-  'Content-Type': 'application/json'
-}
-
 const getLastOrder = async (token: string): Promise<Task> =>
   TaskQueue.execute({
     url: processLocalizedURLAddress(
       getApiEndpointUrl(config.users, 'last_order').replace('{{token}}', token)
-    ),
-    payload: {
-      method: 'GET',
-      mode: 'cors',
-      headers
-    }
+    )
   })
 
 export const UserService: any = {

--- a/src/modules/icmaa-user/store/actions.ts
+++ b/src/modules/icmaa-user/store/actions.ts
@@ -194,7 +194,12 @@ const actions: ActionTree<UserState, RootState> = {
     const apiUrl = processLocalizedURLAddress(endpoint + '/login')
     const fetchOptions = {
       method: 'POST',
-      body: JSON.stringify({ 'access_token': accessToken, version })
+      body: JSON.stringify({ 'access_token': accessToken, version }),
+      headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json'
+      },
+      mode: 'cors' as RequestMode
     }
 
     const resp = await fetch(apiUrl, fetchOptions)


### PR DESCRIPTION
* The request `content-type`- and `accept`-header is by default marked as `application/json` for `Task.execute()` requests but must be explicitly set for `fetch` requests that aren't using the VSF task handler.