### PR TITLE
#220254 Load `Intl` polyfill only on serverside requests

### DIFF
--- a/core/i18n/intl.ts
+++ b/core/i18n/intl.ts
@@ -1,3 +1,4 @@
+import { isServer } from '@vue-storefront/core/helpers'
 import areIntlLocalesSupported from 'intl-locales-supported'
 
 export const importIntlPolyfill = async () => {
@@ -7,7 +8,7 @@ export const importIntlPolyfill = async () => {
 
 export const checkForIntlPolyfill = async (storeView) => {
   const globDTO = typeof window !== 'undefined' ? window : global
-  if (!globDTO.hasOwnProperty('Intl') || !areIntlLocalesSupported(storeView.i18n.defaultLocale)) {
+  if (isServer && (!globDTO.hasOwnProperty('Intl') || !areIntlLocalesSupported(storeView.i18n.defaultLocale))) {
     await importIntlPolyfill()
   }
 }

--- a/src/modules/icmaa-config/helpers/price.ts
+++ b/src/modules/icmaa-config/helpers/price.ts
@@ -4,8 +4,8 @@ import _round from 'lodash-es/round'
 
 export const formatValue = (value, locale?) => {
   if (!locale) {
-    const _storeView = currentStoreView();
-    locale = !_storeView.i18n ? 'en-US' : _storeView.i18n.defaultLocale;
+    const _storeView = currentStoreView()
+    locale = !_storeView.i18n ? 'en-US' : _storeView.i18n.defaultLocale
   }
 
   const price = Math.abs(parseFloat(value))

--- a/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
@@ -48,11 +48,12 @@ export default {
 
           this.notifyUser(notificationData)
         })
-      } catch (message) {
+      } catch (err) {
         this.$store.commit(
           cartMutationTypes.SN_CART + '/' + cartMutationTypes.CART_ADDING_ITEM,
           { isAdding: false }
         )
+        const message = err instanceof Error ? err.message : err
         this.notifyUser(notifications.createNotification({ type: 'error', message }))
       }
     },


### PR DESCRIPTION
* This otherwise can cause an error in specific mobile Chrome versions (v88+) because it won't be able to load the missing language packages
* If we use old NodeJs versions (<=10) then there is loaded only a compact ICU package so we would need to load the missing packages using the polyfill (not tested as we usually using NodeJS version 13+)