### PR TITLE
#221741 Refactore breadcrumbs for mobile viewport

### DIFF
--- a/src/themes/icmaa-imp/components/core/Breadcrumbs.vue
+++ b/src/themes/icmaa-imp/components/core/Breadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="t-flex t-items-center t-text-sm t-text-base-tone">
+  <div class="t-flex t-flex-wrap t-items-center t-text-sm t-text-base-tone">
     <template v-for="(link, index) in paths">
-      <router-link :to="link.route_link" :key="index" class="t-text-base-tone hover:t-text-base-dark" v-if="link.route_link">
+      <router-link :to="link.route_link" :key="index" class="t-text-base-tone hover:t-text-base-dark" :class="{ 't-hidden md:t-inline': !link.visible }" v-if="link.route_link">
         <template v-if="index === 0">
           <material-icon icon="home" size="xs" class="t-align-middle" />
           <span class="t-sr-only">{{ link.name | htmlDecode }}</span>
@@ -10,16 +10,16 @@
           {{ link.name | htmlDecode }}
         </template>
       </router-link>
-      <span v-else :key="index" class="t-text-base-tone">{{ link.name | htmlDecode }}</span>
-      <span class="t-mx-3 lg:t-mx-4 t-text-xs t-font-thin" :key="'bullet-' + index" v-text="spacerCharacter" />
+      <span v-else :key="index" class="t-text-base-tone" :class="{ 't-hidden md:t-inline': !link.visible, 'md:t-hidden': link.placeholder }">{{ link.name | htmlDecode }}</span>
+      <span class="t-mx-3 lg:t-mx-4 t-text-xs t-font-thin" :class="{ 't-hidden md:t-inline': !link.visible || (!showActiveRoute && link.isLast), 'md:t-hidden': link.placeholder }" :key="'bullet-' + index" v-text="spacerCharacter" />
     </template>
-    <span class="t-text-base-tone">{{ current | htmlDecode }}</span>
+    <span class="t-text-base-tone" :class="{ 't-hidden md:t-inline': !showActiveRoute }">{{ current | htmlDecode }}</span>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
-import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 import i18n from '@vue-storefront/i18n'
 import last from 'lodash-es/last'
 
@@ -31,22 +31,25 @@ export default {
     MaterialIcon
   },
   props: {
+    activeRoute: {
+      type: String,
+      default: undefined
+    },
     spacerCharacter: {
       type: String,
       default: '/'
-    },
-    routes: {
-      type: Array,
-      required: false,
-      default: null
     },
     withHomepage: {
       type: Boolean,
       default: true
     },
-    activeRoute: {
-      type: String,
-      default: undefined
+    showActiveRoute: {
+      type: Boolean,
+      default: true
+    },
+    limit: {
+      type: Number,
+      default: 2
     }
   },
   computed: {
@@ -54,20 +57,37 @@ export default {
       getBreadcrumbsRoutes: 'breadcrumbs/getBreadcrumbsRoutes',
       getBreadcrumbsCurrent: 'breadcrumbs/getBreadcrumbsCurrent'
     }),
-    paths () {
-      let routes = this.routes ? this.routes : this.getBreadcrumbsRoutes
+    testLimit () {
+      return this.showActiveRoute ? this.limit - 1 : this.limit
+    },
+    isLong () {
+      return this.routes.length > this.testLimit
+    },
+    routes () {
+      let routes = this.getBreadcrumbsRoutes
 
-      // Remove last element
-      // – got it already in `current`
+      // Remove last element – got it already in `current`
       if (routes.length && last(routes).name === this.current) {
         routes = routes.slice(0, -1)
       }
 
+      return routes
+    },
+    paths () {
+      let routes = this.routes
+      routes = routes.map((r, i) => {
+        return Object.assign(r, {
+          isLast: (routes.length === i + 1),
+          visible: !this.isLong || (this.isLong && (i + 1) > (routes.length - this.testLimit))
+        })
+      })
+
+      if (this.isLong) {
+        routes.unshift({ name: '…', visible: true, placeholder: true })
+      }
+
       if (this.withHomepage) {
-        return [
-          { name: i18n.t('Homepage'), route_link: localizedRoute('/', currentStoreView().storeCode) },
-          ...routes
-        ]
+        routes.unshift({ name: i18n.t('Homepage'), route_link: localizedRoute('/'), visible: true })
       }
 
       return routes

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -3,7 +3,7 @@
     <header class="t-container">
       <div class="t-flex t-flex-wrap t-px-4 t-mb-8">
         <category-extras-header class="t-bg-white t--mx-4 md:t-mx-0 md:t-mt-4 lg:t-w-full" />
-        <breadcrumbs :active-route="getCurrentCategory.name" class="t-w-full t-my-8" />
+        <breadcrumbs :active-route="getCurrentCategory.name" class="t-w-full t-my-4 md:t-my-8" />
         <block-wrapper :components="contentHeader" v-if="contentHeader" />
         <div class="t-w-full">
           <div class="t-flex t-flex-wrap t-items-center t--mx-1 lg:t--mx-2">

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -2,8 +2,7 @@
   <div id="product" data-test-id="product">
     <div class="t-container t-px-4">
       <div class="t--mx-4 lg:t-px-4 t-flex t-flex-wrap">
-        <breadcrumbs class="breadcrumbs t-w-full t-my-8 t-hidden lg:t-flex" />
-        <category-extras-header class="t-bg-white t-border-b t-border-base-lightest" v-if="['xs', 'sm', 'md'].includes(viewport)" :linked-banner="true" :banner-sizes="categoryHeaderBannerSizes" :spotify-logo-limit="spotifyLogoLimit" />
+        <breadcrumbs :show-active-route="false" class="breadcrumbs t-w-full t-my-4 md:t-my-8 t-px-4 md:t-px-0" />
         <product-gallery
           class="product-gallery t-w-full t-border-base-lightest t-border-b t-bg-white lg:t-w-1/2 lg:t-border-b-0"
           :gallery="gallery.map(i => i.src)"
@@ -11,7 +10,7 @@
           :product="product"
         />
         <div class="t-w-full t-p-8 t-bg-white lg:t-w-1/2" :class="{ 'lg:t-flex lg:t-flex-col lg:t-justify-between': isPreorder }">
-          <category-extras-header class="t--mx-8 t--mt-8 t-mb-8 lg:t-pl-px t-border-b t-border-base-lightest" v-if="!['xs', 'sm', 'md'].includes(viewport)" :linked-banner="true" :banner-sizes="categoryHeaderBannerSizes" :spotify-logo-limit="spotifyLogoLimit">
+          <category-extras-header class="t--mx-8 t--mt-8 t-mb-8 lg:t-pl-px t-border-b t-border-base-lightest" :linked-banner="true" :banner-sizes="categoryHeaderBannerSizes" :spotify-logo-limit="spotifyLogoLimit">
             <div class="t-flex" v-if="category">
               <button-component size="sm" @click="goToDepartmentCategory()">
                 {{ $t('More product\'s') }}


### PR DESCRIPTION
# Screenshots:

## CLP / Mobile
<img width="476" alt="Bildschirmfoto 2021-02-11 um 12 09 43" src="https://user-images.githubusercontent.com/6112764/107629326-3d8a4a00-6c62-11eb-904d-6c849f304a40.png">

## CLP / Desktop
<img width="1440" alt="Bildschirmfoto 2021-02-11 um 12 09 34" src="https://user-images.githubusercontent.com/6112764/107629332-3ebb7700-6c62-11eb-961c-b0caa07f110d.png">

## PDP / Mobile
<img width="477" alt="Bildschirmfoto 2021-02-11 um 12 10 26" src="https://user-images.githubusercontent.com/6112764/107629313-382cff80-6c62-11eb-95ac-f58b44f1e4bb.png">

## PDP / Desktop
<img width="1440" alt="Bildschirmfoto 2021-02-11 um 12 10 19" src="https://user-images.githubusercontent.com/6112764/107629322-3b27f000-6c62-11eb-8924-8106e48ccd8a.png">
