### PR TITLE
#222643 Refactor authentication for `/my-account` routes

### DIFF
--- a/core/modules/user/index.ts
+++ b/core/modules/user/index.ts
@@ -27,7 +27,11 @@ export const UserModule: StorefrontModule = async function ({ store }) {
       })
     })
 
-    store.dispatch('user/startSession')
+    /**
+     * In order to be able to overwrite this action we need to uncomment it here.
+     * Look inside the `icmaa-user` module for more info.
+     */
+    // store.dispatch('user/startSession')
   }
 
   store.subscribe((mutation, state) => {

--- a/src/modules/icmaa-review/routes.ts
+++ b/src/modules/icmaa-review/routes.ts
@@ -1,5 +1,5 @@
 const MyAccount = () => import(/* webpackChunkName: "vsf-my-account" */ 'theme/pages/MyAccount.vue')
 
 export default [
-  { name: 'my-order-review', path: '/my-account/order-review/:orderId?', component: MyAccount, props: { activeBlock: 'MyOrderReview' } }
+  { name: 'my-order-review', path: '/my-account/order-review/:orderId?', component: MyAccount, props: { activeBlock: 'MyOrderReview' }, meta: { isSecure: true } }
 ]

--- a/src/modules/icmaa-user/README.md
+++ b/src/modules/icmaa-user/README.md
@@ -1,6 +1,7 @@
 # `icmaa-user` module
 
 * Extend the `user` module and add `customercluster` store.
+* Add before-each router-guard to check for valid user in secure routes based on Vuex state
 * Add Facebook login action to store and configs to `local.json`.
 * Add functionallity for JWT expiration.
 * Add methods to add demographic user-data to session and filter them in CLP
@@ -42,6 +43,8 @@ You need to add the following config to the `config/local.json`:
 We try to overwrite everything needed by extending the Vuex store. But some methods are not highjackable like that – this is a list of core changes.
 
 * We added an `await` to the `cart/authorize` action inside the `restoreCurrentUserFromCache` action in `core/modules/user/store/actions.ts` to be sure to wait for a valid cart.
+* We uncommented the dispatch of the `user/startSession` action on the initialization of the user module. I'd liked to overwrite this asciton and if it isn't uncommented it would be called before my overwrite is applied. So I needed to uncomment it and call during the initialization of the `icmaa-user` module.  
+  The reason I need to overwrite it is to call the `USER_START_SESSION` commit at the end of the function to be able to use a watcher on the `session_started` state property to know when the session is initialized inside a before-each router-guard. I could propably also use the event-bus but this wouldn't apply to the one-direction-data-flow of Vuex and might end-up in timing issues.
 
 ## Todo
 

--- a/src/modules/icmaa-user/index.ts
+++ b/src/modules/icmaa-user/index.ts
@@ -27,14 +27,21 @@ export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store
         const unwatch = store.watch(
           () => store.state.user.session_started,
           value => {
+            const unauthorizedRedirect = localizedRoute({ name: 'home', query: { fwd: 'login' } })
+            const timeout = setTimeout(() => {
+              Logger.log('User is not authorized in time, redirect to login.', 'user')()
+              next(unauthorizedRedirect)
+            }, 2000)
+
             if (value !== null) {
               unwatch()
+              clearTimeout(timeout)
 
               if (store.getters['user/isLoggedIn'] === true) {
                 next()
               } else {
-                Logger.log('User is not authorized, redirect to login.', 'icmaa-user')()
-                next(localizedRoute({ name: 'home', query: { fwd: 'login' } }))
+                Logger.log('User is not authorized, redirect to login.', 'user')()
+                next(unauthorizedRedirect)
               }
             }
           }

--- a/src/modules/icmaa-user/index.ts
+++ b/src/modules/icmaa-user/index.ts
@@ -18,7 +18,9 @@ export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store
           if (store.getters['user/isLoggedIn']) {
             next()
           } else {
-            next(localizedRoute('/'))
+            next(
+              localizedRoute({ name: 'home', query: { fwd: 'login' } })
+            )
           }
         })
         return

--- a/src/modules/icmaa-user/index.ts
+++ b/src/modules/icmaa-user/index.ts
@@ -3,6 +3,7 @@ import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { extendStore } from '@vue-storefront/core/helpers'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { isServer } from '@vue-storefront/core/helpers'
+import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 
 import { ExtendedUserStore } from './store'
 import * as types from './store/mutation-types'
@@ -10,14 +11,21 @@ import * as types from './store/mutation-types'
 export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store, router }) {
   extendStore('user', ExtendedUserStore)
 
-  router.beforeEach((to, from, next) => {
-    if (!isServer && to.meta.isSecure === true) {
-      console.error('TEST', to, store.getters['user/isLoggedIn'])
+  if (!isServer) {
+    router.beforeEach(async (to, from, next) => {
+      if (to.meta.isSecure === true && !store.getters['user/isLoggedIn']) {
+        EventBus.$once('session-after-started', () => {
+          if (store.getters['user/isLoggedIn']) {
+            next()
+          } else {
+            next(localizedRoute('/'))
+          }
+        })
+        return
+      }
       next()
-    }
-
-    next()
-  })
+    })
+  }
 
   store.subscribe((mutation, state) => {
     if (mutation.type.endsWith(types.USER_ADD_SESSION_DATA) || mutation.type.endsWith(types.USER_RMV_SESSION_DATA)) {

--- a/src/modules/icmaa-user/index.ts
+++ b/src/modules/icmaa-user/index.ts
@@ -7,8 +7,17 @@ import { isServer } from '@vue-storefront/core/helpers'
 import { ExtendedUserStore } from './store'
 import * as types from './store/mutation-types'
 
-export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store }) {
+export const IcmaaExtendedUserModule: StorefrontModule = async function ({ store, router }) {
   extendStore('user', ExtendedUserStore)
+
+  router.beforeEach((to, from, next) => {
+    if (!isServer && to.meta.isSecure === true) {
+      console.error('TEST', to, store.getters['user/isLoggedIn'])
+      next()
+    }
+
+    next()
+  })
 
   store.subscribe((mutation, state) => {
     if (mutation.type.endsWith(types.USER_ADD_SESSION_DATA) || mutation.type.endsWith(types.USER_RMV_SESSION_DATA)) {

--- a/src/modules/icmaa-user/store/index.ts
+++ b/src/modules/icmaa-user/store/index.ts
@@ -9,6 +9,7 @@ import merge from 'lodash-es/merge'
 
 export const ExtendedUserStore: Module<UserState, any> = {
   state: merge(userStore.state, {
+    session_started: null,
     sessionData: {}
   }),
   mutations,

--- a/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/AddToCartSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/AddToCartSidebar.vue
@@ -45,11 +45,8 @@
 </template>
 
 <script>
-import i18n from '@vue-storefront/i18n'
 import { mapGetters } from 'vuex'
-import { notifications } from '@vue-storefront/core/modules/cart/helpers'
 import { filterChangedProduct } from '@vue-storefront/core/modules/catalog/events'
-import Composite from '@vue-storefront/core/mixins/composite'
 import ProductPriceMixin from 'theme/mixins/product/priceMixin'
 import ProductOptionsMixin from 'theme/mixins/product/optionsMixin'
 import ProductAddToCartMixin from 'theme/mixins/product/addtocartMixin'
@@ -65,7 +62,7 @@ import LoaderBackground from 'theme/components/core/LoaderBackground'
 
 export default {
   name: 'AddToCartSidebar',
-  mixins: [ Composite, ProductOptionsMixin, ProductAddToCartMixin, ProductPriceMixin, ProductStockAlertMixin ],
+  mixins: [ ProductOptionsMixin, ProductAddToCartMixin, ProductPriceMixin, ProductStockAlertMixin ],
   components: {
     Sidebar,
     DefaultSelector,

--- a/src/themes/icmaa-imp/components/core/blocks/Checkout/OrderReview.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Checkout/OrderReview.vue
@@ -109,7 +109,6 @@
 
 <script>
 import { required } from 'vuelidate/lib/validators'
-import Composite from '@vue-storefront/core/mixins/composite'
 
 import BaseCheckbox from 'theme/components/core/blocks/Form/BaseCheckbox'
 import ButtonComponent from 'theme/components/core/blocks/Button'
@@ -126,7 +125,7 @@ export default {
     CartSummary,
     Modal
   },
-  mixins: [OrderReview, Composite],
+  mixins: [OrderReview],
   validations: {
     orderReview: {
       terms: {

--- a/src/themes/icmaa-imp/components/core/blocks/Checkout/ThankYouPage.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Checkout/ThankYouPage.vue
@@ -76,7 +76,6 @@
 </template>
 
 <script>
-import Composite from '@vue-storefront/core/mixins/composite'
 import Breadcrumbs from 'theme/components/core/Breadcrumbs'
 import BaseTextarea from 'theme/components/core/blocks/Form/BaseTextarea'
 import ButtonComponent from 'theme/components/core/blocks/Button'
@@ -89,7 +88,7 @@ import { MailerModule } from '@vue-storefront/core/modules/mailer'
 
 export default {
   name: 'ThankYouPage',
-  mixins: [Composite, VueOfflineMixin, EmailForm],
+  mixins: [VueOfflineMixin, EmailForm],
   beforeCreate () {
     registerModule(MailerModule)
   },

--- a/src/themes/icmaa-imp/components/core/blocks/MyAccount/MyAddresses.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/MyAccount/MyAddresses.vue
@@ -157,17 +157,6 @@
           :class="[ hasState ? 't-w-full lg:t-w-1/2' : 't-w-1/2 lg:t-w-1/4']"
           class="t-px-2 t-mb-4"
         />
-        <country-select
-          name="country_id"
-          id="country_id"
-          v-model="address.country_id"
-          :label="$t('Country') + ' *'"
-          :validations="[{
-            condition: !validation.country_id.required && validation.country_id.$error,
-            text: $t('Field is required.')
-          }]"
-          class="t-w-1/2 lg:t-w-1/4 t-px-2 t-mb-4"
-        />
         <base-select
           name="region_id"
           id="region_id"
@@ -181,6 +170,17 @@
           }]"
           class="t-w-1/2 lg:t-w-1/4 t-px-2 t-mb-4"
           v-if="hasState"
+        />
+        <country-select
+          name="country_id"
+          id="country_id"
+          v-model="address.country_id"
+          :label="$t('Country') + ' *'"
+          :validations="[{
+            condition: !validation.country_id.required && validation.country_id.$error,
+            text: $t('Field is required.')
+          }]"
+          class="t-w-1/2 lg:t-w-1/4 t-px-2 t-mb-4"
         />
         <div class="t-w-full lg:t-w-1/2 t-px-2 t-mb-4">
           <base-input

--- a/src/themes/icmaa-imp/components/core/blocks/MyAccount/Navigation.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/MyAccount/Navigation.vue
@@ -80,9 +80,6 @@ export default {
     }
   },
   methods: {
-    isActive (link) {
-      return this.$route.path.endsWith(link)
-    },
     logout () {
       this.$store.dispatch('user/logout', { silent: false })
         .then(() => {

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -44,10 +44,10 @@ export default {
 
     const { fwd } = this.$route.query
     if (fwd) {
-      if (fwd === 'login') {
+      if (fwd === 'login' && !this.$store.getters('user/isLoggedIn')) {
         this.$store.commit('ui/setAuthElem', 'login')
         this.$store.dispatch('ui/showModal', 'modal-signup')
-      } else if (fwd === 'create' || fwd === 'register') {
+      } else if ((fwd === 'create' || fwd === 'register') && !this.$store.getters('user/isLoggedIn')) {
         this.$store.commit('ui/setAuthElem', 'register')
         this.$store.dispatch('ui/showModal', 'modal-signup')
       } else if (fwd === 'cart') {

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { currentStoreView, localizedRoute } from '@vue-storefront/core/lib/multistore'
 
 import Lazyload from 'icmaa-cms/components/Lazyload'
@@ -37,6 +38,11 @@ export default {
     ProductListingWidget,
     CmsBlock
   },
+  computed: {
+    ...mapGetters({
+      isLoggedIn: 'user/isLoggedIn'
+    })
+  },
   mounted () {
     if (!this.isLoggedIn && localStorage.getItem('redirect')) {
       this.$store.dispatch('ui/showModal', 'modal-signup')
@@ -44,10 +50,10 @@ export default {
 
     const { fwd } = this.$route.query
     if (fwd) {
-      if (fwd === 'login' && !this.$store.getters('user/isLoggedIn')) {
+      if (fwd === 'login' && !this.isLoggedIn) {
         this.$store.commit('ui/setAuthElem', 'login')
         this.$store.dispatch('ui/showModal', 'modal-signup')
-      } else if ((fwd === 'create' || fwd === 'register') && !this.$store.getters('user/isLoggedIn')) {
+      } else if ((fwd === 'create' || fwd === 'register') && !this.isLoggedIn) {
         this.$store.commit('ui/setAuthElem', 'register')
         this.$store.dispatch('ui/showModal', 'modal-signup')
       } else if (fwd === 'cart') {

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -13,9 +13,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 import { Logger } from '@vue-storefront/core/lib/logger'
-import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 
 import i18n from '@vue-storefront/i18n'
 import Composite from '@vue-storefront/core/mixins/composite'

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -1,35 +1,34 @@
 <template>
   <div id="my_account" class="t-container t-px-4">
-    <div class="t-flex t--mx-2 t-py-4">
-      <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="viewport && !['xs','sm','md'].includes(viewport)">
+    <div class="t-flex t--mx-2 t-py-4" v-if="isValidCustomer">
+      <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="!['xs','sm','md'].includes(viewport)">
         <navigation />
       </div>
-      <no-ssr>
-        <div class="t-w-full lg:t-w-3/4 t-px-2">
-          <component :is="this.$props.activeBlock" />
-        </div>
-      </no-ssr>
+      <div class="t-w-full lg:t-w-3/4 t-px-2">
+        <component :is="this.$props.activeBlock" />
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
-import { currentStoreView, localizedRoute } from '@vue-storefront/core/lib/multistore'
+import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 
 import i18n from '@vue-storefront/i18n'
 import Composite from '@vue-storefront/core/mixins/composite'
 import NoSSR from 'vue-no-ssr'
 
-const Navigation = () => import(/* webpackChunkName: "vsf-myaccount-navigation" */'../components/core/blocks/MyAccount/Navigation')
-const MyProfile = () => import(/* webpackChunkName: "vsf-myaccount-myprofile" */'../components/core/blocks/MyAccount/MyProfile')
-const MyAddresses = () => import(/* webpackChunkName: "vsf-myaccount-myaddresses" */'../components/core/blocks/MyAccount/MyAddresses')
-const MyNewsletter = () => import(/* webpackChunkName: "vsf-myaccount-mynewsletter" */'../components/core/blocks/MyAccount/MyNewsletter')
-const MyGiftcert = () => import(/* webpackChunkName: "vsf-myaccount-mygiftcert" */'../components/core/blocks/MyAccount/MyGiftcert')
-const MyOrders = () => import(/* webpackChunkName: "vsf-myaccount-myorders" */'../components/core/blocks/MyAccount/MyOrders')
-const MyOrder = () => import(/* webpackChunkName: "vsf-myaccount-myorder" */'../components/core/blocks/MyAccount/MyOrder')
-const MyProductAlerts = () => import(/* webpackChunkName: "vsf-myaccount-myproductalerts" */'../components/core/blocks/MyAccount/MyProductAlerts')
+const Navigation = () => import(/* webpackChunkName: "vsf-myaccount-navigation" */'theme/components/core/blocks/MyAccount/Navigation')
+const MyProfile = () => import(/* webpackChunkName: "vsf-myaccount-myprofile" */'theme/components/core/blocks/MyAccount/MyProfile')
+const MyAddresses = () => import(/* webpackChunkName: "vsf-myaccount-myaddresses" */'theme/components/core/blocks/MyAccount/MyAddresses')
+const MyNewsletter = () => import(/* webpackChunkName: "vsf-myaccount-mynewsletter" */'theme/components/core/blocks/MyAccount/MyNewsletter')
+const MyGiftcert = () => import(/* webpackChunkName: "vsf-myaccount-mygiftcert" */'theme/components/core/blocks/MyAccount/MyGiftcert')
+const MyOrders = () => import(/* webpackChunkName: "vsf-myaccount-myorders" */'theme/components/core/blocks/MyAccount/MyOrders')
+const MyOrder = () => import(/* webpackChunkName: "vsf-myaccount-myorder" */'theme/components/core/blocks/MyAccount/MyOrder')
+const MyProductAlerts = () => import(/* webpackChunkName: "vsf-myaccount-myproductalerts" */'theme/components/core/blocks/MyAccount/MyProductAlerts')
 const MyOrderReview = () => import(/* webpackChunkName: "vsf-myaccount-myorderreview" */'icmaa-review/components/MyAccount/MyOrderReview')
 
 export default {
@@ -56,20 +55,18 @@ export default {
   beforeMount () {
     this.$bus.$on('myAccount-before-updateUser', this.onBeforeUpdateUser)
   },
-  async mounted () {
-    await this.$store.dispatch('user/startSession')
-    if (!this.$store.getters['user/isLoggedIn']) {
-      localStorage.setItem('redirect', this.$route.path)
-      this.$router.push(localizedRoute('/', currentStoreView().storeCode))
-    }
-  },
   destroyed () {
     this.$bus.$off('myAccount-before-updateUser', this.onBeforeUpdateUser)
   },
   computed: {
     ...mapGetters({
-      viewport: 'ui/getViewport'
+      viewport: 'ui/getViewport',
+      isLoggedIn: 'user/isLoggedIn',
+      isLocalDataLoaded: 'user/isLocalDataLoaded'
     }),
+    isValidCustomer () {
+      return this.isLocalDataLoaded && this.isLoggedIn
+    },
     metaTitle () {
       const titleMap = {
         'MyAccount': 'My profile',
@@ -142,11 +139,11 @@ export default {
       meta: this.$route.meta.description ? [{ vmid: 'description', name: 'description', content: this.$route.meta.description }] : []
     }
   },
-  asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data
-    return new Promise((resolve, reject) => {
-      if (context) context.output.cacheTags.add(`my-account`)
-      resolve()
-    })
+  async asyncData ({ context }) {
+    if (context) {
+      context.output.cacheTags
+        .add(`my-account`)
+    }
   }
 }
 </script>

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -23,7 +23,6 @@ import { mapGetters } from 'vuex'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 import i18n from '@vue-storefront/i18n'
-import Composite from '@vue-storefront/core/mixins/composite'
 import NoSSR from 'vue-no-ssr'
 
 const Navigation = () => import(/* webpackChunkName: "vsf-myaccount-navigation" */'theme/components/core/blocks/MyAccount/Navigation')
@@ -38,7 +37,6 @@ const MyOrderReview = () => import(/* webpackChunkName: "vsf-myaccount-myorderre
 
 export default {
   name: 'MyAccount',
-  mixins: [Composite],
   props: {
     activeBlock: {
       type: String,

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -1,13 +1,15 @@
 <template>
   <div id="my_account" class="t-container t-px-4">
-    <div class="t-flex t--mx-2 t-py-4" v-if="isValidCustomer">
-      <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="!['xs','sm','md'].includes(viewport)">
-        <navigation />
+    <no-ssr>
+      <div class="t-flex t--mx-2 t-py-4" v-if="isLoggedIn">
+        <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="!['xs','sm','md'].includes(viewport)">
+          <navigation />
+        </div>
+        <div class="t-w-full lg:t-w-3/4 t-px-2">
+          <component :is="this.$props.activeBlock" />
+        </div>
       </div>
-      <div class="t-w-full lg:t-w-3/4 t-px-2">
-        <component :is="this.$props.activeBlock" />
-      </div>
-    </div>
+    </no-ssr>
   </div>
 </template>
 
@@ -59,12 +61,8 @@ export default {
   computed: {
     ...mapGetters({
       viewport: 'ui/getViewport',
-      isLoggedIn: 'user/isLoggedIn',
-      isLocalDataLoaded: 'user/isLocalDataLoaded'
+      isLoggedIn: 'user/isLoggedIn'
     }),
-    isValidCustomer () {
-      return this.isLocalDataLoaded && this.isLoggedIn
-    },
     metaTitle () {
       const titleMap = {
         'MyAccount': 'My profile',

--- a/src/themes/icmaa-imp/pages/MyAccount.vue
+++ b/src/themes/icmaa-imp/pages/MyAccount.vue
@@ -1,15 +1,20 @@
 <template>
   <div id="my_account" class="t-container t-px-4">
-    <no-ssr>
-      <div class="t-flex t--mx-2 t-py-4" v-if="isLoggedIn">
-        <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="!['xs','sm','md'].includes(viewport)">
-          <navigation />
-        </div>
-        <div class="t-w-full lg:t-w-3/4 t-px-2">
-          <component :is="this.$props.activeBlock" />
-        </div>
+    <div class="t-flex t--mx-2 t-py-4">
+      <div class="t-hidden lg:t-flex t-w-1/4 t-px-2" v-if="!['xs','sm','md'].includes(viewport)">
+        <navigation />
       </div>
-    </no-ssr>
+      <div class="t-w-full lg:t-w-3/4 t-px-2">
+        <no-ssr>
+          <component :is="this.$props.activeBlock" v-if="isLoggedIn" />
+          <div slot="placeholder">
+            <div class="t-p-4 t-bg-white t-text-base-light">
+              {{ $t('Please wait') }} ...
+            </div>
+          </div>
+        </no-ssr>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/src/themes/icmaa-imp/pages/PageNotFound.vue
+++ b/src/themes/icmaa-imp/pages/PageNotFound.vue
@@ -29,7 +29,6 @@
 
 <script>
 import i18n from '@vue-storefront/i18n'
-import Composite from '@vue-storefront/core/mixins/composite'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import ButtonComponent from 'theme/components/core/blocks/Button'
 
@@ -38,7 +37,6 @@ export default {
   components: {
     ButtonComponent
   },
-  mixins: [Composite],
   async asyncData ({ store, route, context }) {
     Logger.log('Entering asyncData for PageNotFound ' + new Date())()
     if (context) {

--- a/src/themes/icmaa-imp/router/index.ts
+++ b/src/themes/icmaa-imp/router/index.ts
@@ -10,16 +10,18 @@ const Compare = () => import(/* webpackChunkName: "vsf-compare" */ 'theme/pages/
 const MyAccount = () => import(/* webpackChunkName: "vsf-my-account" */ 'theme/pages/MyAccount.vue')
 const ResetPassword = () => import(/* webpackChunkName: "vsf-reset-password" */ 'theme/pages/ResetPassword.vue')
 
+const secureRoute = { meta: { isSecure: true } }
+
 let routes = [
   { name: 'home', path: '/', component: Home },
   { name: 'home-pwa', path: '/pwa.html', component: Home },
-  { name: 'my-account', path: '/my-account', component: MyAccount },
-  { name: 'my-addresses', path: '/my-account/addresses', component: MyAccount, props: { activeBlock: 'MyAddresses' } },
-  { name: 'my-coupons', path: '/my-account/coupons', component: MyAccount, props: { activeBlock: 'MyGiftcert' } },
-  { name: 'my-newsletter', path: '/my-account/newsletter', component: MyAccount, props: { activeBlock: 'MyNewsletter' } },
-  { name: 'my-orders', path: '/my-account/orders', component: MyAccount, props: { activeBlock: 'MyOrders' } },
-  { name: 'my-order', path: '/my-account/orders/:orderId', component: MyAccount, props: { activeBlock: 'MyOrder' } },
-  { name: 'my-product-alerts', path: '/my-account/product-alerts', component: MyAccount, props: { activeBlock: 'MyProductAlerts' } },
+  { name: 'my-account', path: '/my-account', component: MyAccount, ...secureRoute },
+  { name: 'my-addresses', path: '/my-account/addresses', component: MyAccount, props: { activeBlock: 'MyAddresses' }, ...secureRoute },
+  { name: 'my-coupons', path: '/my-account/coupons', component: MyAccount, props: { activeBlock: 'MyGiftcert' }, ...secureRoute },
+  { name: 'my-newsletter', path: '/my-account/newsletter', component: MyAccount, props: { activeBlock: 'MyNewsletter' }, ...secureRoute },
+  { name: 'my-orders', path: '/my-account/orders', component: MyAccount, props: { activeBlock: 'MyOrders' }, ...secureRoute },
+  { name: 'my-order', path: '/my-account/orders/:orderId', component: MyAccount, props: { activeBlock: 'MyOrder' }, ...secureRoute },
+  { name: 'my-product-alerts', path: '/my-account/product-alerts', component: MyAccount, props: { activeBlock: 'MyProductAlerts' }, ...secureRoute },
   { name: 'compare', path: '/compare', component: Compare, props: { title: 'Compare Products' } },
   { name: 'error', path: '/error', component: ErrorPage, meta: { layout: 'minimal' } },
   { name: 'virtual-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site


### PR DESCRIPTION
* At the moment this was solved by a check when the `MyAccount` SFC is mounted. But this can lead to a race-condition where you will be logged out because the authentication isn't done yet despited you are already logged in.
* I refactored the authorization process for secure routes to use a global `beforeEach` router-guard for all routes that have the `isSecure` meta-tag in their definition.
* Then I refactored the `user/startSession` action to set the `session_started` state value at its end – this way I can create a state-watcher during the router-guard and redirect to the login page if the user isn't logged-in or the authorization times-out.
* I also needed to comment the original dispatch of `user/startSession` during the module-initialization and call it during the module-initialization of `icmaa-user` to be able to overwrite this action, otherwise it would be dispatched before our overwrite is done.
* Further I removed the `composite` mixin as we don't need it and some clean-up in some components.