### PR TITLE
#222918 Hotfix for stateful-singletons in `currentStoreView()` and more

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      
+      - name: Install
+        uses: bahmutov/npm-install@v1
 
       - name: Run ESlint
         run: |
-          yarn
           yarn lint
 
   test-unit:
@@ -35,15 +37,10 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Get repository name, and branch name
-        run: |
-          echo "APP=$(echo ${GITHUB_REPOSITORY##*/})" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-
       - name: Checkout "icmaa/shop-workspace" repo
         run: |
           rm -rf shop-workspace
-          export CONFIG_BRANCH=$(if [ "${{ github.base_ref }}" != "master" ]; then echo "-b develop"; fi)
+          export CONFIG_BRANCH=$(if [[ ! ${{ github.base_ref }} =~ ^master ]]; then echo "-b develop"; fi)
           git clone --no-tags --depth 1 https://${{ secrets.PAT }}@github.com/icmaa/shop-workspace $CONFIG_BRANCH
 
       - name: Sync config JSON files
@@ -54,7 +51,6 @@ jobs:
 
       - name: Run Jest-Unit-Tests
         run: |
-          yarn
           yarn test:unit
 
   tests-e2e:
@@ -82,7 +78,7 @@ jobs:
       - name: Checkout "icmaa/shop-workspace" repo
         run: |
           rm -rf shop-workspace
-          export CONFIG_BRANCH=$(if [ "${{ github.base_ref }}" != "master" ]; then echo "-b develop"; fi)
+          export CONFIG_BRANCH=$(if [[ ! ${{ github.base_ref }} =~ ^master ]]; then echo "-b develop"; fi)
           git clone --no-tags --depth 1 https://${{ secrets.PAT }}@github.com/icmaa/shop-workspace $CONFIG_BRANCH
 
       - name: Sync config JSON files
@@ -94,7 +90,7 @@ jobs:
       #   run: echo "$GITHUB_CONTEXT"
 
       - name: Install
-        uses: bahmutov/npm-install@v1.1.0
+        uses: bahmutov/npm-install@v1
 
       - name: Build
         run: yarn build

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -57,7 +57,7 @@ export async function loadLanguageAsync (lang: string): Promise<string> {
           loadedLanguages.push(lang)
           return setI18nLanguage(lang)
         } catch (e) {
-          Logger.debug('Unable to load translation', e.message)()
+          Logger.error('Unable to load translation', e.message)()
           return ''
         }
       }

--- a/core/lib/multistore/index.ts
+++ b/core/lib/multistore/index.ts
@@ -43,7 +43,7 @@ export function getExtendedStoreviewConfig (storeView: StoreView): StoreView {
 /**
  * Returns base storeView object that can be created without storeCode
  */
-function buildBaseStoreView (): StoreView {
+export function buildBaseStoreView (): StoreView {
   return cloneDeep({
     tax: config.tax,
     i18n: config.i18n,

--- a/core/lib/multistore/index.ts
+++ b/core/lib/multistore/index.ts
@@ -55,9 +55,18 @@ function buildBaseStoreView (): StoreView {
 }
 
 export function currentStoreView (): StoreView {
-  const serverStoreView = get(global, 'process.storeView', undefined)
-  const clientStoreView = get(rootStore, 'state.storeView', undefined)
-  return (isServer ? serverStoreView : clientStoreView) || buildBaseStoreView()
+  /**
+   * @see https://github.com/vuestorefront/vue-storefront/issues/5639
+   * We don't need to load it from global variable in SSR as it will be overwritten between multiple concurrent requests.
+   * This will cause a bunch of errors on shared nodes. As the rootState is unique for each request we can just use
+   * it without an extra global process variable for SSR. The rootState is initialized in the `createApp` factory at
+   * beginning this should be soon enough for all processes that need the store-view.
+   *
+   * const serverStoreView = get(global, 'process.storeView', undefined)
+   * const clientStoreView = get(rootStore, 'state.storeView', undefined)
+   * return (isServer ? serverStoreView : clientStoreView) || buildBaseStoreView()
+   */
+  return get(rootStore, 'state.storeView', undefined) || buildBaseStoreView()
 }
 
 export async function prepareStoreView (storeCode: string): Promise<StoreView> {
@@ -82,9 +91,10 @@ export async function prepareStoreView (storeCode: string): Promise<StoreView> {
     storeView = coreHooksExecutors.beforeStoreViewChanged(storeView)
     rootStore.state.storeView = storeView
 
-    if (global && isServer) {
-      (global.process as any).storeView = storeView
-    }
+    // See `currentStoreView()` for explaination
+    // if (global && isServer) {
+    //   (global.process as any).storeView = storeView
+    // }
 
     await loadLanguageAsync(storeView.i18n.defaultLocale)
   }
@@ -179,7 +189,7 @@ export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig 
 
   const storeCode = (forcedStoreCode && getStoreViewByStoreCode(forcedStoreCode))
     ? forcedStoreCode
-    : currentStoreView().storeCode
+    : (currentStoreView() ? currentStoreView().storeCode : false)
 
   if (storeCode) {
     if (typeof routeObj !== 'object') {

--- a/src/modules/icmaa-meta/mixins/productMeta.ts
+++ b/src/modules/icmaa-meta/mixins/productMeta.ts
@@ -1,14 +1,12 @@
 import { mapGetters } from 'vuex'
 import { htmlDecode } from '@vue-storefront/core/filters'
 import { getThumbnailPath } from '@vue-storefront/core/helpers'
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   computed: {
     ...mapGetters({
       getOptionLabel: 'attribute/getOptionLabel',
-      storeConfig: 'icmaaConfig/getCurrentStoreConfig',
-      store: 'icmaaConfig/getCurrentStore'
+      storeConfig: 'icmaaConfig/getCurrentStoreConfig'
     }),
     currencyCode () {
       return this.storeConfig ? this.storeConfig.i18n.currencyCode : ''
@@ -43,26 +41,7 @@ export default {
     }
   },
   metaInfo () {
-    /**
-     * @todo We can't load the current store-view from state management yet, the value is always empty in metaInfo().
-     * I opened an issue here: @see https://github.com/DivanteLtd/vue-storefront/issues/3674
-     */
-    const storeView = currentStoreView()
-
     return {
-      link: [
-        // {
-        //   rel: 'amphtml',
-        //   href: this.$router.resolve(localizedRoute({
-        //     name: this.product.type_id + '-product-amp',
-        //     params: {
-        //       parentSku: this.product.parentSku ? this.product.parentSku : this.product.sku,
-        //       slug: this.product.slug,
-        //       childSku: this.product.sku
-        //     }
-        //   }, storeView.storeCode)).href
-        // }
-      ],
       title: this.translatedProductName,
       meta: [
         { vmid: 'description', name: 'description', content: htmlDecode(this.product.description) },
@@ -73,7 +52,7 @@ export default {
         { name: 'product.price', content: this.productPrice },
         { name: 'product:condition', content: 'new' },
         { name: 'product:availability', content: this.product.stock ? this.product.stock.is_in_stock : false },
-        { name: 'product:price:currency', content: storeView.i18n.currencyCode },
+        { name: 'product:price:currency', content: this.storeConfig.i18n.currencyCode },
         { name: 'product:price:amount', content: this.productFinalPrice },
         { name: 'product:brand', content: this.getOptionLabel({ attributeKey: this.productBandOrBrandCode, optionId: this.productBandOrBrand }) },
         ...this.productFbImages

--- a/src/themes/icmaa-imp/index.js
+++ b/src/themes/icmaa-imp/index.js
@@ -12,7 +12,7 @@ import { claimsStore } from 'theme/store/claims'
 import { uiStore } from 'theme/store/ui'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
-once('__VUE_EXTEND_DROPPOINT_VPB__', () => {
+once('__VUE_EXTEND_THEME__', () => {
   Vue.use(VueProgressBar, { thickness: '4px' })
   Vue.use(VueScrollTo, { offset: -55 })
   Vue.mixin(mixins)

--- a/src/themes/icmaa-imp/test/e2e/integration/Menu/main.spec.ts
+++ b/src/themes/icmaa-imp/test/e2e/integration/Menu/main.spec.ts
@@ -8,7 +8,7 @@ describe('Menu sidebar', () => {
       .should('have.length.gt', 0)
 
     cy.get('@sidebar')
-      .find('a')
+      .find('.sidebar-content a:not([rel*="noopener"])')
       .random()
       .as('link')
       .should('have.attr', 'href')


### PR DESCRIPTION
* #222918 Bugfix for stateful-singletons in `currentStoreView()`
  * This is related to `[dispatcher] Route not found de-fi-category null` errors and `storeCode of undefined` exceptions
  * See issue: vuestorefront#5639 for more detailed information
* Add a store-config fallback to`icmaaConfig/getCurrentStoreConfig` getter for `metaInfo` calls on initial-state
* Update Github-Actions to use new `yarn install` and support master branch
* Drop an error if `loadLanguageAsync` fails
* Rename `once` event in `icmaa-imp` theme entrypoint
* Improve flacky E2E test for main-navigation