### PR TITLE
#223922 Bugfix for `icmaa-google-tag-manager` page-view hook

### DIFF
--- a/core/modules/catalog-next/hooks.ts
+++ b/core/modules/catalog-next/hooks.ts
@@ -1,5 +1,6 @@
-import { createListenerHook, createMutatorHook } from '@vue-storefront/core/lib/hooks'
-import { Category } from './types/Category';
+import { createListenerHook } from '@vue-storefront/core/lib/hooks'
+import { Category } from './types/Category'
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 const {
   hook: categoryPageVisitedHook,
@@ -9,7 +10,7 @@ const {
 const {
   hook: productPageVisitedHook,
   executor: productPageVisitedExecutor
-} = createListenerHook<Category>()
+} = createListenerHook<Product>()
 
 /** Only for internal usage */
 const catalogHooksExecutors = {

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -194,6 +194,11 @@ export default {
         await composeInitialPageState(this.$store, this.$route, false, this.$route.params.pagesize || this.pageSize)
         this.loading = false
       }
+    },
+    getCurrentCategory (nCategory, oCategory) {
+      if (nCategory.id && nCategory.id !== oCategory.id) {
+        catalogHooksExecutors.categoryPageVisited(nCategory)
+      }
     }
   },
   async asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data - and it's always executed before parent component methods

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -211,10 +211,14 @@ export default {
     })
   },
   watch: {
-    product (newVal, oldVal) {
-      if (newVal.id !== oldVal.id) {
+    product (nProduct, oProduct) {
+      if (nProduct.id !== oProduct.id) {
         this.getQuantity()
         this.userHasSelectedVariant = false
+      }
+
+      if (nProduct.parentId) {
+        catalogHooksExecutors.productPageVisited(nProduct)
       }
     }
   },


### PR DESCRIPTION
* As we removed the key from the main view mount-point to increase rendering-performance, the `mounted` method is only called once when the SFC is mounted and not when its updated. For example: a movement between two products doesn't rerender or mount the product SFC, it just updates its data. So I needed to ad a watcher for the current data on CLP and PDP.
* Add correct generic type to `catalog-next/productPageVisitedHook`