### PR TITLE
Release 2021-03-15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,8 +114,9 @@ jobs:
           # spec: integration/Cms/**/*
           record: true
           parallel: true
+          group: ${{ runner.os }}
           tag: ${{ github.event_name }},${{ github.event_name }}/${{ github.event.action }}
-          ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.action }}-${{ github.run_number }}'
+          ci-build-id: 'continous-integration-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}'
         env:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/modules/catalog-next/hooks.ts
+++ b/core/modules/catalog-next/hooks.ts
@@ -1,5 +1,6 @@
-import { createListenerHook, createMutatorHook } from '@vue-storefront/core/lib/hooks'
-import { Category } from './types/Category';
+import { createListenerHook } from '@vue-storefront/core/lib/hooks'
+import { Category } from './types/Category'
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 const {
   hook: categoryPageVisitedHook,
@@ -9,7 +10,7 @@ const {
 const {
   hook: productPageVisitedHook,
   executor: productPageVisitedExecutor
-} = createListenerHook<Category>()
+} = createListenerHook<Product>()
 
 /** Only for internal usage */
 const catalogHooksExecutors = {

--- a/src/modules/icmaa-external-checkout/pages/Success.vue
+++ b/src/modules/icmaa-external-checkout/pages/Success.vue
@@ -23,6 +23,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import i18n from '@vue-storefront/i18n'
 
 import GoogleCustomerReview from 'icmaa-google-tag-manager/components/GoogleCustomerReview'
 import CheckoutSuccessGtmMixin from 'icmaa-google-tag-manager/mixins/checkoutSuccessGtm'
@@ -82,6 +83,14 @@ export default {
       if (!this.isLoggedIn && this.lastOrder) {
         this.$bus.$emit('checkout-success-last-order-loaded', this.lastOrder)
       }
+    }
+  },
+  metaInfo () {
+    return {
+      title: i18n.t('Order complete'),
+      meta: [
+        { vmid: 'robots', name: 'robots', content: 'noindex, nofollow' }
+      ]
     }
   }
 }

--- a/src/themes/icmaa-imp/components/core/blocks/Reviews/Reviews.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Reviews/Reviews.vue
@@ -59,7 +59,7 @@ export default {
       reviewsTotalRating: 'review/getReviewsTotalRating'
     }),
     productId () {
-      return this.product.id
+      return this.product.parentId || this.product.id
     },
     total () {
       return this.reviewsCount + ' ' + (this.reviewsCount > 1 ? i18n.t('Reviews') : i18n.t('Review'))

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -194,6 +194,11 @@ export default {
         await composeInitialPageState(this.$store, this.$route, false, this.$route.params.pagesize || this.pageSize)
         this.loading = false
       }
+    },
+    getCurrentCategory (nCategory, oCategory) {
+      if (nCategory.id && nCategory.id !== oCategory.id) {
+        catalogHooksExecutors.categoryPageVisited(nCategory)
+      }
     }
   },
   async asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data - and it's always executed before parent component methods

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -211,10 +211,14 @@ export default {
     })
   },
   watch: {
-    product (newVal, oldVal) {
-      if (newVal.id !== oldVal.id) {
+    product (nProduct, oProduct) {
+      if (nProduct.id !== oProduct.id) {
         this.getQuantity()
         this.userHasSelectedVariant = false
+      }
+
+      if (nProduct.parentId) {
+        catalogHooksExecutors.productPageVisited(nProduct)
       }
     }
   },

--- a/src/themes/icmaa-imp/resource/i18n/de-DE.csv
+++ b/src/themes/icmaa-imp/resource/i18n/de-DE.csv
@@ -219,6 +219,7 @@
 "Open wishlist","Wunschliste öffnen"
 "Order ID","ID der Bestellung"
 "Order Summary","Bestellübersicht"
+"Order complete","Bestellung abgeschlossen"
 "Order confirmation","Bestellbestätigung"
 "Order date","Bestelldatum"
 "Order number","Bestellnummer"

--- a/src/themes/icmaa-imp/resource/i18n/en-US.csv
+++ b/src/themes/icmaa-imp/resource/i18n/en-US.csv
@@ -221,6 +221,7 @@
 "Open wishlist","Open wishlist"
 "Order ID","Order ID"
 "Order Summary","Order Summary"
+"Order complete","Order complete"
 "Order confirmation","Order confirmation"
 "Order","Order"
 "Order-Review","Order-Review"

--- a/src/themes/icmaa-imp/test/e2e/integration/Catalog/price.spec.ts
+++ b/src/themes/icmaa-imp/test/e2e/integration/Catalog/price.spec.ts
@@ -33,6 +33,9 @@ const findProductInStock = (run: number = 1, tries: number = 3) => {
   }
 
   cy.visitCategoryPage()
+
+  cy.registerStockApiRequest()
+
   cy.getByTestId('ProductTile')
     .random()
     .then($product => {

--- a/src/themes/icmaa-imp/test/e2e/support/commands.ts
+++ b/src/themes/icmaa-imp/test/e2e/support/commands.ts
@@ -156,6 +156,8 @@ Cypress.Commands.add('visitProductDetailPage', (options?) => {
     cy.visitCategoryPage(options)
   }
 
+  cy.registerStockApiRequest()
+
   cy.getByTestId('ProductTile')
     .random()
     .findByTestId('productLink')
@@ -310,7 +312,14 @@ Cypress.Commands.add('findImageWithPlaceholder', { prevSubject: 'element' }, (su
   cy.wrap(subject).find(selector + ':not(.t-hidden)')
 })
 
+Cypress.Commands.add('registerStockApiRequest', () => {
+  cy.intercept({ method: 'GET', pathname: '/api/stock/check*' })
+    .as('apiStockReq')
+})
+
 Cypress.Commands.add('checkAvailabilityOfCurrentProduct', () => {
+  cy.wait('@apiStockReq')
+
   cy.getByTestId('AddToCart').then($button => {
     if ($button.attr('disabled')) {
       cy.wrap(false).as('availability')

--- a/src/themes/icmaa-imp/test/e2e/typings/index.d.ts
+++ b/src/themes/icmaa-imp/test/e2e/typings/index.d.ts
@@ -283,6 +283,18 @@ declare namespace Cypress {
 
     /**
      * Check availability of current product.
+     * Adds alias `apiStockReq` for further use.
+     *
+     * @example
+     * cy.registerStockApiRequest()
+     * //...
+     * cy.wait('@apiStockReq')
+     */
+    registerStockApiRequest(): Chainable<Window>,
+
+    /**
+     * Check availability of current product.
+     * Its important that the `registerStockApiRequest` is called to register the stock-api route before the PDP is opened.
      * Adds alias `availability` for further use.
      * Adds alias `productType` for further use.
      *


### PR DESCRIPTION
* #223921 Add `noindex, nofollow` to `/order-success` page (#584)
* #223922 Bugfix for `icmaa-google-tag-manager` page-view hook when moving between the same SFC (#585)
* #223087 Bugfix for missing reviews on PDP (#586)
* Add `group` and correct `build-id` to Github-Actions E2E tests (#588)