### PR TITLE
#224741 Bugfix for race-condition during registration of `icmaa-cdn`

### DIFF
--- a/src/modules/icmaa-cdn/README.md
+++ b/src/modules/icmaa-cdn/README.md
@@ -10,7 +10,7 @@ Load custom image provider to support external CDN services.
 * `config.images.useExactUrlsNoProxy` must be `true` / enabled 
 
 * Add the following configs to your `config/local.json`:
-  ```
+  ```json
   "images": {
     "useExactUrlsNoProxy": true
   },
@@ -25,12 +25,21 @@ Load custom image provider to support external CDN services.
 
 ## Add a new provider
 
-If you wan't to add another CDN provider, you can add a new modules classes inside the `provider/NewProvider.ts`.
+If you wan't to add another CDN provider, you can add a new class inside the modules `provider/` folder.
 
-You also need to add the dynamic import variable to the `providers` array in the `index.ts` like:  
-`newprovider: () => import(/* webpackChunkName: "vsf-icmaa-cdn-newprovider" */ './provider/NewProvider')`
+You then also need to import the new provider and add it to the `providers` array in the `index.ts` like:
+```ts
+import scalecommerce from './provider/ScaleCommerce'
+
+const providers: { [provider: string]: ImageHook } = {
+  // ...
+  scalecommerce
+}
+```
 
 Then add your desired configs under the `icmaa_cdn` configs path.
+
+> It would be nice to use dynamic-imports for this (as before) but the module registration is synchronous and therefore a dynamic-import can lead into a race condition where the picture component is using the wrong image-path because the cdn provider isn't initialized yet. So we can't lazyload the providers using an import-promise.
 
 ## Todo
 

--- a/src/modules/icmaa-cdn/index.ts
+++ b/src/modules/icmaa-cdn/index.ts
@@ -2,20 +2,26 @@ import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { coreHooks } from '@vue-storefront/core/hooks'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
-import { ImakeHook } from './types/HookTypes'
+import { ImageHook } from './types/HookTypes'
+import scalecommerce from './provider/ScaleCommerce'
 
-const providers: { [provider: string]: () => Promise<ImakeHook> } = {
-  scalecommerce: () => import(/* webpackChunkName: "vsf-icmaa-cdn-scalecommerce" */ './provider/ScaleCommerce')
+const providers: { [provider: string]: ImageHook } = {
+  scalecommerce
 }
 
 export const IcmaaCdnModule: StorefrontModule = ({ appConfig }) => {
+  /**
+   * It would be nice to let this be asynchronous (as before) but the module registration isn't and therefore
+   * can lead into a race condition where the picture component is using the wrong image-path because the cdn
+   * provider isn't initialized yet. So we can't lazyload the providers using an import-promise.
+   */
   const cdn = appConfig.icmaa_cdn && appConfig.icmaa_cdn.provider && appConfig.icmaa_cdn.provider !== '' ? appConfig.icmaa_cdn.provider : false
   if (cdn && appConfig.images.useExactUrlsNoProxy && providers.hasOwnProperty(cdn)) {
-    const provider = providers[cdn]()
-    provider.then(({ default: hook }) => {
-      coreHooks.afterProductThumbnailPathGenerate(hook.afterProductThumbnailPathGenerate)
-    }).catch(e => {
+    try {
+      const provider = providers[cdn]
+      coreHooks.afterProductThumbnailPathGenerate(provider.afterProductThumbnailPathGenerate)
+    } catch (err) {
       Logger.error('Could not load provider:', 'icmaa-cdn', cdn)()
-    })
+    }
   }
 }

--- a/src/modules/icmaa-cdn/types/HookTypes.ts
+++ b/src/modules/icmaa-cdn/types/HookTypes.ts
@@ -9,8 +9,6 @@ export interface ImageHookReturn {
   path: string
 }
 
-export interface ImakeHook {
-  default: {
-    afterProductThumbnailPathGenerate(params: ImageHookProperties): ImageHookReturn
-  }
+export interface ImageHook {
+  afterProductThumbnailPathGenerate(params: ImageHookProperties): ImageHookReturn
 }

--- a/src/themes/icmaa-imp/components/core/ProductImage.vue
+++ b/src/themes/icmaa-imp/components/core/ProductImage.vue
@@ -9,7 +9,6 @@
 import config from 'config'
 import cloneDeep from 'lodash-es/cloneDeep'
 import LozadMixin from 'theme/mixins/lozadMixin'
-import { getThumbnailPath } from '@vue-storefront/core/helpers'
 
 export default {
   name: 'ProductImage',
@@ -83,7 +82,7 @@ export default {
   methods: {
     getImageWithSize (width = 0, height = 0) {
       const src = this.image || ''
-      return getThumbnailPath(src, width, height)
+      return this.getThumbnail(src, width, height)
     },
     onLoaded () {
       if (this.loading === true) {

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Header.vue
@@ -15,13 +15,11 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { getThumbnailPath } from '@vue-storefront/core/helpers'
 import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers'
 import DepartmentLogo from 'theme/components/core/blocks/CategoryExtras/DepartmentLogo'
 import PictureComponent from 'theme/components/core/blocks/Picture'
 
 import { isDatetimeInBetween } from 'icmaa-config/helpers/datetime'
-import sampleSize from 'lodash-es/sampleSize'
 
 export default {
   name: 'CategoryExtrasHeader',

--- a/src/themes/icmaa-imp/components/core/blocks/Picture.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Picture.vue
@@ -104,12 +104,10 @@ export default {
       })
     },
     defaultImage () {
-      const test = {
+      return {
         src: this.getImageWithSize(this.image, this.width, this.height),
         srcAt2x: this.getImageWithSize(this.image, this.width * 2, this.height * 2)
       }
-
-      return test
     }
   },
   methods: {

--- a/src/themes/icmaa-imp/components/core/blocks/Picture.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Picture.vue
@@ -104,10 +104,13 @@ export default {
       })
     },
     defaultImage () {
-      return {
+      const test = {
         src: this.getImageWithSize(this.image, this.width, this.height),
         srcAt2x: this.getImageWithSize(this.image, this.width * 2, this.height * 2)
       }
+      console.error('image', test)
+
+      return test
     }
   },
   methods: {

--- a/src/themes/icmaa-imp/components/core/blocks/Picture.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Picture.vue
@@ -10,7 +10,6 @@
 import Placeholder from 'theme/components/core/blocks/Placeholder'
 import LozadMixin from 'theme/mixins/lozadMixin'
 import cloneDeep from 'lodash-es/cloneDeep'
-import { getThumbnailPath } from '@vue-storefront/core/helpers'
 
 export default {
   name: 'Picture',
@@ -120,7 +119,7 @@ export default {
       return `${path}`
     },
     getImageWithSize (src, width = 0, height = 0) {
-      return getThumbnailPath(src, width, height, this.pathType || 'media')
+      return this.getThumbnail(src, width, height, this.pathType || 'media')
     },
     prepareClassProp (value) {
       if (typeof value === 'string') {

--- a/src/themes/icmaa-imp/components/core/blocks/Picture.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Picture.vue
@@ -108,7 +108,6 @@ export default {
         src: this.getImageWithSize(this.image, this.width, this.height),
         srcAt2x: this.getImageWithSize(this.image, this.width * 2, this.height * 2)
       }
-      console.error('image', test)
 
       return test
     }

--- a/src/themes/icmaa-imp/components/core/blocks/RetinaImage.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/RetinaImage.vue
@@ -8,7 +8,6 @@
 
 <script>
 import Placeholder from 'theme/components/core/blocks/Placeholder'
-import { getThumbnailPath } from '@vue-storefront/core/helpers'
 
 export default {
   name: 'RetinaImage',
@@ -61,14 +60,14 @@ export default {
     },
     baseImage () {
       if (this.resize) {
-        return getThumbnailPath(this.path, this.width, this.height, 'media')
+        return this.getMediaThumbnail(this.path, this.width, this.height, 'media')
       }
 
       return this.path
     },
     retinaImage () {
       if (this.resize) {
-        return getThumbnailPath(this.path, this.width * 2, this.height * 2, 'media')
+        return this.getMediaThumbnail(this.path, this.width * 2, this.height * 2, 'media')
       }
 
       return this.baseImage.replace(/(\.\w{3,4})(\?\w*)?$/gm, '@2x$1$2')

--- a/src/themes/icmaa-imp/components/core/blocks/Teaser/TeaserFullsize.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Teaser/TeaserFullsize.vue
@@ -15,7 +15,6 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { getThumbnailPath } from '@vue-storefront/core/helpers'
 import TeaserMixin from 'icmaa-teaser/mixins/teaserMixin'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
 import PictureComponent from 'theme/components/core/blocks/Picture'


### PR DESCRIPTION
* The VSF module registration is synchronous and our `icmaa-cdn` module used a dynamic-import to register custom CDN providers during registration. This could lead into the problem that the `afterProductThumbnailPathGenerate` hook is not yet set when `getThumbnail` is called and will deliver wrong image paths.