### PR TITLE
#224199 Bugfix for wrong promo-banner in CLP

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Category/PromoBanner.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/PromoBanner.vue
@@ -50,6 +50,10 @@ export default {
       return this.product.promo_id
     },
     promo () {
+      if (this.promoId === '') {
+        return false
+      }
+
       if (this.product.special_price && parseFloat(this.product.special_price) > 0) {
         return this.map.find(v => v.key === 'sale')
       }


### PR DESCRIPTION
* When the product had an promo-id the field isn't `null` or `false`, it's just an empty string and we need to consider that