### PR TITLE
Add Breacrumb-Data to Datalayer

### DIFF
--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -79,6 +79,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
 
       const storeView = currentStoreView()
       const { currencyCode } = storeView.i18n
+      const breadcrumbs = rootGetters['breadcrumbs/getBreadcrumbsRoutes']
 
       switch (type) {
         case 'product':
@@ -89,6 +90,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
 
           DTO = {
             event: 'icmaa-product-view',
+            breadcrumb: breadcrumbs,
             ecommerce: {
               currencyCode,
               detail: {
@@ -107,6 +109,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
 
           DTO = {
             event: 'icmaa-category-view',
+            breadcrumb: breadcrumbs,
             ecommerce: {
               currencyCode,
               categoryId: category.id,

--- a/src/themes/icmaa-imp/components/core/blocks/Footer/Newsletter.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Footer/Newsletter.vue
@@ -16,7 +16,7 @@
     </div>
     <i18n path="Data is not given to third parties and unsubscription is possible at any time. {policy}" tag="p" class="t-text-xs t-text-base-light t-leading-none t-mb-4">
       <template #policy>
-        <router-link :to="localizedRoute('/service-imprint')">
+        <router-link :to="localizedRoute('/service-privacy')">
           {{ $t('Privacy Policy') }}
         </router-link>
       </template>


### PR DESCRIPTION
- add Breadcrumb-Data to these events `icmaa-product-view` and `icmaa-categroy-view`
- after the Release I will create the structured Data Tag via GTM

<img width="537" alt="Bildschirmfoto 2021-03-23 um 15 07 57" src="https://user-images.githubusercontent.com/22610088/112159535-90540b80-8be9-11eb-97f2-6136ea807e80.png">
