### PR TITLE
#222888 Ignore `*/p/*` and `*/c/*` routes in `robots.txt`

### DIFF
--- a/src/modules/robots/robots.txt
+++ b/src/modules/robots/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Disallow: /*?*
-Disallow /c/*
-Disallow /p/*
+Disallow /*/c/*
+Disallow /*/p/*
 Allow: /*.svg?*
 Allow: /*.css?*
 Allow: /*.js?*

--- a/src/modules/robots/robots.txt
+++ b/src/modules/robots/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Disallow: /*?*
-Disallow /*/c/*
-Disallow /*/p/*
+Disallow: /*/c/*
+Disallow: /*/p/*
 Allow: /*.svg?*
 Allow: /*.css?*
 Allow: /*.js?*

--- a/src/modules/robots/robots.txt
+++ b/src/modules/robots/robots.txt
@@ -1,5 +1,8 @@
 User-agent: *
 Disallow: /*?*
+Disallow /c/*
+Disallow /p/*
+Allow: /*.svg?*
 Allow: /*.css?*
 Allow: /*.js?*
 Allow: /*.xml?*


### PR DESCRIPTION
Google indexed automatically this urls.
_Indexiert, nicht in Sitemap gesendet_

`/p/:parentSku/:slug` - https://www.impericon.com/de/p/AH2008-010/nike-legasee-jdi-blackwhite-leggings/G395305_RED

`/c/:slug` - https://www.impericon.com/pt/c/volcom