### PR TITLE
#222842 Add `syncCartWhenLocalStorageChange` event to window to keep tabs in sync

### DIFF
--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -1,7 +1,7 @@
 import rootStore from '@vue-storefront/core/store';
 
 function getItemsFromStorage ({ key }) {
-  if (key === 'shop/cart/current-cart') {
+  if (key.endsWith('shop/cart/current-cart')) {
     const storedItems = JSON.parse(localStorage[key])
     rootStore.dispatch('cart/syncCartWhenLocalStorageChange', { items: storedItems })
   }

--- a/src/themes/icmaa-imp/components/core/blocks/Header/ButtonCart.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Header/ButtonCart.vue
@@ -4,6 +4,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import { syncCartWhenLocalStorageChange } from '@vue-storefront/core/modules/cart/helpers'
 import ButtonIcon from 'theme/components/core/blocks/Header/ButtonIcon'
 
 export default {
@@ -25,6 +26,12 @@ export default {
   computed: {
     ...mapGetters({
       quantity: 'cart/getItemsTotalQuantity'
+    })
+  },
+  mounted () {
+    syncCartWhenLocalStorageChange.addEventListener()
+    this.$once('hook:beforeDestroy', () => {
+      syncCartWhenLocalStorageChange.removeEventListener()
     })
   }
 }


### PR DESCRIPTION
* Related PR of base-repository vuestorefront/vue-storefront#4083
* I've also added a bugfix for multistore environment vuestorefront/vue-storefront#5711