### PR TITLE
Prevent exception with the `lozadObserver` on component destroy

### DIFF
--- a/src/themes/icmaa-imp/mixins/lozadMixin.ts
+++ b/src/themes/icmaa-imp/mixins/lozadMixin.ts
@@ -52,10 +52,10 @@ export default {
 
       this.lozadObserver = lozad($el, Object.assign(defaults, options))
       this.lozadObserver.observe()
+
+      this.$once('hook:destroyed', () => {
+        this.lozadObserver.observer.disconnect()
+      })
     }
-  },
-  destroyed () {
-    if (!this.lozadObserver) return
-    this.lozadObserver.observer.disconnect()
   }
 }


### PR DESCRIPTION
* This happens when the component is destroyed before the observer is bound