### PR TITLE
#229652 - wrong E-Mail Format

### DIFF
--- a/src/modules/icmaa-cms/helpers/index.ts
+++ b/src/modules/icmaa-cms/helpers/index.ts
@@ -6,7 +6,7 @@ export const getCurrentStoreCode = (): string => {
 }
 
 export const localizeRouterLink = (text: string): string => {
-  const regexLink = /(<a\shref=")(?!http)(.*?)(">)(.*?)(<\/a>)/gm
+  const regexLink = /(<a\shref=")(?!http|mailto)(.*?)(">)(.*?)(<\/a>)/gm
   text = text.replace(regexLink, (match, g1, g2, g3, g4) =>
     ['<router-link to="', g2, g3, g4, '</router-link>'].join(''))
 


### PR DESCRIPTION
Remove `localizeRouterLink` from E-Mail Links

## Related ticket
TCK-229652

## Checklist

- [ ] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [ ] I'm aware of depending changes in other repositories
