### PR TITLE
#227190 Add `universal-link` component to support external links

### DIFF
--- a/src/modules/icmaa-competitions/pages/Competition.vue
+++ b/src/modules/icmaa-competitions/pages/Competition.vue
@@ -19,13 +19,13 @@
         </div>
         <div class="t-w-full lg:t-w-1/2 t-pt-px lg:t-pl-px lg:t-pt-0 t-flex">
           <div class="t-relative t-flex-1 t-bg-white">
-            <router-link :to="competition.bannerLink" class="t-flex">
+            <a :href="competition.bannerLink" class="t-flex">
               <picture-component :alt="competition.bannerLinkText | stripHTML" :src="bannerImage" :width="624" :height="312" :placeholder="true" :sizes="sizes" ratio="1:1" class="t-flex-1 t-self-start" />
-            </router-link>
-            <router-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
+            </a>
+            <a :href="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
               <span v-text="competition.bannerLinkText" class="t-flex-1" />
               <material-icon icon="keyboard_arrow_right" size="lg" class="t-text-base-lighter t-ml-2" />
-            </router-link>
+            </a>
           </div>
         </div>
       </div>

--- a/src/modules/icmaa-competitions/pages/Competition.vue
+++ b/src/modules/icmaa-competitions/pages/Competition.vue
@@ -19,13 +19,13 @@
         </div>
         <div class="t-w-full lg:t-w-1/2 t-pt-px lg:t-pl-px lg:t-pt-0 t-flex">
           <div class="t-relative t-flex-1 t-bg-white">
-            <a :href="competition.bannerLink" class="t-flex">
+            <router-link :to="competition.bannerLink" class="t-flex">
               <picture-component :alt="competition.bannerLinkText | stripHTML" :src="bannerImage" :width="624" :height="312" :placeholder="true" :sizes="sizes" ratio="1:1" class="t-flex-1 t-self-start" />
-            </a>
-            <a :href="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
+            </router-link>
+            <router-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
               <span v-text="competition.bannerLinkText" class="t-flex-1" />
               <material-icon icon="keyboard_arrow_right" size="lg" class="t-text-base-lighter t-ml-2" />
-            </a>
+            </router-link>
           </div>
         </div>
       </div>

--- a/src/modules/icmaa-competitions/pages/Competition.vue
+++ b/src/modules/icmaa-competitions/pages/Competition.vue
@@ -19,13 +19,13 @@
         </div>
         <div class="t-w-full lg:t-w-1/2 t-pt-px lg:t-pl-px lg:t-pt-0 t-flex">
           <div class="t-relative t-flex-1 t-bg-white">
-            <router-link :to="competition.bannerLink" class="t-flex">
+            <universal-link :to="competition.bannerLink" class="t-flex">
               <picture-component :alt="competition.bannerLinkText | stripHTML" :src="bannerImage" :width="624" :height="312" :placeholder="true" :sizes="sizes" ratio="1:1" class="t-flex-1 t-self-start" />
-            </router-link>
-            <router-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
+            </universal-link>
+            <universal-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
               <span v-text="competition.bannerLinkText" class="t-flex-1" />
               <material-icon icon="keyboard_arrow_right" size="lg" class="t-text-base-lighter t-ml-2" />
-            </router-link>
+            </universal-link>
           </div>
         </div>
       </div>
@@ -70,6 +70,7 @@ import { Logger } from '@vue-storefront/core/lib/logger'
 import FormComponent from 'theme/components/core/blocks/Form/Form'
 import PictureComponent from 'theme/components/core/blocks/Picture'
 import ButtonComponent from 'theme/components/core/blocks/Button'
+import UniversalLink from 'theme/components/core/blocks/Link'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
 
 export default {
@@ -78,6 +79,7 @@ export default {
     FormComponent,
     ButtonComponent,
     PictureComponent,
+    UniversalLink,
     MaterialIcon
   },
   data () {

--- a/src/themes/icmaa-imp/components/core/blocks/Link.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Link.vue
@@ -1,0 +1,20 @@
+<template>
+  <router-link :to="to" v-if="!isExternal">
+    <slot />
+  </router-link>
+  <a :href="to" target="_blank" v-else>
+    <slot />
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'Link',
+  props: [ 'to' ],
+  computed: {
+    isExternal () {
+      return typeof this.to === 'string' && this.to.startsWith('http')
+    }
+  }
+}
+</script>


### PR DESCRIPTION
We obviously sometimes need links to external sites. To be able to have universal code undepending of the entered url-path, I've added a new wrapper component which checks if it's an external link and then uses a `<a>` or `<router-link>`.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-227190

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
