### PR TITLE
Hotfix for GAE flex environment support of NodeJS 14.17 LTS

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 … Short description of your changes with links to related PR's of other repos.
 
 ## Related ticket
-<!--  Put related Redmin issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->
+<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->
 
 TCK-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,17 @@ jobs:
           NODE_CONFIG_ENV: ${{ env.ENV }}
           NODE_APP_INSTANCE: ${{ matrix.env.MANDANT }}
 
+      # The newest NodeJS LTS version isn't supported by GAE flex engine
+      # @see https://github.com/GoogleCloudPlatform/nodejs-docker/issues/214
+      - name: Hotfix for new NodeJS 14.17.* LTS version
+        if: ${{ env.ENV == 'production' }}
+        run: |
+          sed -i 's/"node": "^14"/"node": "14.16.x"/' package.json
+
       - id: deploy
         uses: google-github-actions/deploy-appengine@main
         with:
           credentials: ${{ env.ENV == 'production' && secrets.GCP_VSF_SA_KEY_PROD || secrets.GCP_VSF_SA_KEY_TEST }}
           deliverables: app-${{ matrix.env.MANDANT }}-${{ env.ENV == 'production' && 'prod' || 'test' }}.yaml
           version: ${{ env.VERSION_NAME }}
-          promote: ${{ env.ENV == 'production' && 'false' || 'true' }}
+          # promote: ${{ env.ENV == 'production' && 'false' || 'true' }}

--- a/app-imp-prod.yaml
+++ b/app-imp-prod.yaml
@@ -15,7 +15,7 @@ automatic_scaling:
   max_num_instances: 10
   cool_down_period_sec: 60
   cpu_utilization:
-    target_utilization: 0.50
+    target_utilization: 0.60
 readiness_check:
   path: "/_ah/readiness_check"
 liveness_check:

--- a/app-imp-prod.yaml
+++ b/app-imp-prod.yaml
@@ -15,7 +15,7 @@ automatic_scaling:
   max_num_instances: 10
   cool_down_period_sec: 60
   cpu_utilization:
-    target_utilization: 0.35
+    target_utilization: 0.50
 readiness_check:
   path: "/_ah/readiness_check"
 liveness_check:


### PR DESCRIPTION
GAE has a bug where it will drop an error for the latest NodeJS LTS version as he thinks it's not a trusted one:
```
The Node.js binary could not be verified.
```

We could just change the version number in the package JSON to `14.16.x` but then the GAE standard environment won't work because they force you to always use the [latest major version](https://cloud.google.com/appengine/docs/standard/nodejs/runtime#nodejs_version). Thats why we need to monkey-patch the `package.json` in the production build step until it is solved.

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
