### PR TITLE
Release 2021-05-21

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 … Short description of your changes with links to related PR's of other repos.
 
 ## Related ticket
-<!--  Put related Redmin issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->
+<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->
 
 TCK-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,17 @@ jobs:
           NODE_CONFIG_ENV: ${{ env.ENV }}
           NODE_APP_INSTANCE: ${{ matrix.env.MANDANT }}
 
+      # The newest NodeJS LTS version isn't supported by GAE flex engine
+      # @see https://github.com/GoogleCloudPlatform/nodejs-docker/issues/214
+      - name: Hotfix for new NodeJS 14.17.* LTS version
+        if: ${{ env.ENV == 'production' }}
+        run: |
+          sed -i 's/"node": "^14"/"node": "14.16.x"/' package.json
+
       - id: deploy
         uses: google-github-actions/deploy-appengine@main
         with:
           credentials: ${{ env.ENV == 'production' && secrets.GCP_VSF_SA_KEY_PROD || secrets.GCP_VSF_SA_KEY_TEST }}
           deliverables: app-${{ matrix.env.MANDANT }}-${{ env.ENV == 'production' && 'prod' || 'test' }}.yaml
           version: ${{ env.VERSION_NAME }}
-          promote: ${{ env.ENV == 'production' && 'false' || 'true' }}
+          # promote: ${{ env.ENV == 'production' && 'false' || 'true' }}

--- a/app-imp-prod.yaml
+++ b/app-imp-prod.yaml
@@ -15,7 +15,7 @@ automatic_scaling:
   max_num_instances: 10
   cool_down_period_sec: 60
   cpu_utilization:
-    target_utilization: 0.35
+    target_utilization: 0.60
 readiness_check:
   path: "/_ah/readiness_check"
 liveness_check:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Vue.js, PWA eCommerce frontend",
   "private": true,
   "engines": {
-    "node": "14.16.x",
+    "node": "^14",
     "yarn": "^1"
   },
   "repository": {

--- a/src/modules/icmaa-cms/helpers/index.ts
+++ b/src/modules/icmaa-cms/helpers/index.ts
@@ -6,7 +6,7 @@ export const getCurrentStoreCode = (): string => {
 }
 
 export const localizeRouterLink = (text: string): string => {
-  const regexLink = /(<a\shref=")(?!http)(.*?)(">)(.*?)(<\/a>)/gm
+  const regexLink = /(<a\shref=")(?!http|mailto)(.*?)(">)(.*?)(<\/a>)/gm
   text = text.replace(regexLink, (match, g1, g2, g3, g4) =>
     ['<router-link to="', g2, g3, g4, '</router-link>'].join(''))
 

--- a/src/modules/icmaa-competitions/pages/Competition.vue
+++ b/src/modules/icmaa-competitions/pages/Competition.vue
@@ -19,13 +19,13 @@
         </div>
         <div class="t-w-full lg:t-w-1/2 t-pt-px lg:t-pl-px lg:t-pt-0 t-flex">
           <div class="t-relative t-flex-1 t-bg-white">
-            <router-link :to="competition.bannerLink" class="t-flex">
+            <universal-link :to="competition.bannerLink" class="t-flex">
               <picture-component :alt="competition.bannerLinkText | stripHTML" :src="bannerImage" :width="624" :height="312" :placeholder="true" :sizes="sizes" ratio="1:1" class="t-flex-1 t-self-start" />
-            </router-link>
-            <router-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
+            </universal-link>
+            <universal-link :to="competition.bannerLink" class="t-flex t-items-center t-w-full lg:t-absolute lg:t-bottom-0 t-bg-white t-p-4 lg:t-px-6 lg:t-py-8 t-text-primary t-text-xl">
               <span v-text="competition.bannerLinkText" class="t-flex-1" />
               <material-icon icon="keyboard_arrow_right" size="lg" class="t-text-base-lighter t-ml-2" />
-            </router-link>
+            </universal-link>
           </div>
         </div>
       </div>
@@ -70,6 +70,7 @@ import { Logger } from '@vue-storefront/core/lib/logger'
 import FormComponent from 'theme/components/core/blocks/Form/Form'
 import PictureComponent from 'theme/components/core/blocks/Picture'
 import ButtonComponent from 'theme/components/core/blocks/Button'
+import UniversalLink from 'theme/components/core/blocks/Link'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
 
 export default {
@@ -78,6 +79,7 @@ export default {
     FormComponent,
     ButtonComponent,
     PictureComponent,
+    UniversalLink,
     MaterialIcon
   },
   data () {

--- a/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/afterRegistration.ts
@@ -24,6 +24,14 @@ export const registerCustomPageEvents = () => {
     const event = rootStore.getters['icmaaGoogleTagManager/gtmEventPayload']('search')
     IcmaaGoogleTagManagerExecutors.onGtmPageView({ type: event.event, event })
   })
+
+  EventHooks.pageNotFound(() => {
+    const event = Object.assign(
+      rootStore.getters['icmaaGoogleTagManager/gtmEventPayload'](),
+      { event: 'icmaa-page-not-found' }
+    )
+    IcmaaGoogleTagManagerExecutors.onGtmPageView({ type: event.event, event })
+  })
 }
 
 export function afterRegistration () {

--- a/src/modules/icmaa-google-tag-manager/hooks/index.ts
+++ b/src/modules/icmaa-google-tag-manager/hooks/index.ts
@@ -13,6 +13,11 @@ const {
 } = createListenerHook<{ type: string, event: any }>()
 
 const {
+  hook: pageNotFoundHook,
+  executor: pageNotFoundExecutor
+} = createListenerHook<void>()
+
+const {
   hook: onSearchResultHook,
   executor: onSearchResultExecutor
 } = createListenerHook<{ term: string, results: Product[] }>()
@@ -49,6 +54,7 @@ const {
 
 const IcmaaGoogleTagManagerExecutors = {
   afterEach: afterEachExecutor,
+  pageNotFound: pageNotFoundExecutor,
   onGtmPageView: onGtmPageViewExecutor,
   onSearchResult: onSearchResultExecutor,
   searchResultVisited: searchResultVisitedExecutor,
@@ -61,6 +67,7 @@ const IcmaaGoogleTagManagerExecutors = {
 
 const IcmaaGoogleTagManager = {
   afterEach: afterEachHook,
+  pageNotFound: pageNotFoundHook,
   onGtmPageView: onGtmPageViewHook,
   onSearchResult: onSearchResultHook,
   searchResultVisited: searchResultVisitedHook,

--- a/src/modules/icmaa-google-tag-manager/index.ts
+++ b/src/modules/icmaa-google-tag-manager/index.ts
@@ -12,7 +12,7 @@ import { afterRegistration } from './hooks/afterRegistration'
 
 import { isServer } from '@vue-storefront/core/helpers'
 
-export const disallowList = [ 'product', 'category', 'search' ]
+export const disallowList = [ 'product', 'category', 'search', 'page-not-found' ]
 
 export const IcmaaGoogleTagManagerModule: StorefrontModule = function ({ store, router, appConfig }) {
   store.registerModule('icmaaGoogleTagManager', icmaaGoogleTagManagerModule)

--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -91,7 +91,6 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
           DTO = {
             event: 'icmaa-product-view',
             breadcrumb: breadcrumbs,
-            documentTitle: currentProduct.description,
             ecommerce: {
               currencyCode,
               detail: {
@@ -111,7 +110,6 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
           DTO = {
             event: 'icmaa-category-view',
             breadcrumb: breadcrumbs,
-            documentTitle: category.ceMetaTitle || category.ceTitle,
             ecommerce: {
               currencyCode,
               categoryId: category.id,
@@ -139,8 +137,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
         customerLoggedIn: rootGetters['user/isLoggedIn'],
         customerEmail: rootGetters['user/getUserEmail'],
         storeCode: storeView.storeCode,
-        urlPath: rootGetters['url/getCurrentRoute'].path || '',
-        documentTitle: rootGetters['icmaaMeta/getData'].title || ''
+        urlPath: rootGetters['url/getCurrentRoute'].path || ''
       }
 
       return Object.assign(defaultDTO, DTO)

--- a/src/themes/icmaa-imp/components/core/blocks/Link.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Link.vue
@@ -1,0 +1,20 @@
+<template>
+  <router-link :to="to" v-if="!isExternal">
+    <slot />
+  </router-link>
+  <a :href="to" target="_blank" v-else>
+    <slot />
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'Link',
+  props: [ 'to' ],
+  computed: {
+    isExternal () {
+      return typeof this.to === 'string' && this.to.startsWith('http')
+    }
+  }
+}
+</script>

--- a/src/themes/icmaa-imp/pages/PageNotFound.vue
+++ b/src/themes/icmaa-imp/pages/PageNotFound.vue
@@ -34,12 +34,18 @@
 <script>
 import i18n from '@vue-storefront/i18n'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { IcmaaGoogleTagManagerExecutors } from 'icmaa-google-tag-manager/hooks'
 import ButtonComponent from 'theme/components/core/blocks/Button'
 
 export default {
   name: 'PageNotFound',
   components: {
     ButtonComponent
+  },
+  methods: {
+    toggleSearchpanel () {
+      this.$store.dispatch('ui/setSidebar', { key: 'searchpanel' })
+    }
   },
   async asyncData ({ store, route, context }) {
     Logger.log('Entering asyncData for PageNotFound ' + new Date())()
@@ -48,10 +54,8 @@ export default {
       context.server.response.statusCode = 404
     }
   },
-  methods: {
-    toggleSearchpanel () {
-      this.$store.dispatch('ui/setSidebar', { key: 'searchpanel' })
-    }
+  mounted () {
+    IcmaaGoogleTagManagerExecutors.pageNotFound()
   },
   metaInfo () {
     const description = this.$route.meta.description ? [{ vmid: 'description', name: 'description', content: this.$route.meta.description }] : []

--- a/src/themes/icmaa-imp/router/index.ts
+++ b/src/themes/icmaa-imp/router/index.ts
@@ -35,7 +35,7 @@ let routes = [
   { name: 'search', path: '/search/:term', component: SearchResult, meta: { gtm: 'search' } },
   { name: 'create-password', path: '/create-password', component: ResetPassword },
   { name: 'create-password-old-rewrite', path: '/customer/account/resetpassword', component: ResetPassword },
-  { name: 'page-not-found', path: '*', component: PageNotFound }
+  { name: 'page-not-found', path: '*', component: PageNotFound, meta: { gtm: 'page-not-found' } }
 ]
 
 /** ICMAA / Custom cms routes */


### PR DESCRIPTION
* #229652 Wrong format for emails on CMS pages (#656)
* Hotfix for GAE flex environment support of NodeJS 14.17 LTS (#658, #662)
* #224313 Add page-type for 404-pages in icmaa-google-tag-manager module (#660)
* #227190 Add universal-link component to support external links (#661)