### PR TITLE
#226629 Add support for custom tiles in sub-navigation sidebar

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
@@ -97,7 +97,7 @@ export default {
       return this.mainNavigation.genderNavigation || false
     },
     mainNavigationItems () {
-      return this.mainNavigation.mainNavigation.slice(0, 2) || false
+      return this.tiles || this.mainNavigation.mainNavigation.slice(0, 2)
     },
     navigation () {
       return this.sub.navigation || false
@@ -124,6 +124,9 @@ export default {
     },
     logos () {
       return this.sub.logos || false
+    },
+    tiles () {
+      return this.sub.tiles || false
     },
     logoLineProps () {
       if (Array.isArray(this.logos)) {

--- a/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
@@ -97,7 +97,7 @@ export default {
       return this.mainNavigation.genderNavigation || false
     },
     mainNavigationItems () {
-      return this.tiles || this.mainNavigation.mainNavigation.slice(0, 2)
+      return this.tiles || this.mainNavigation.mainNavigation.slice(0, 2) || false
     },
     navigation () {
       return this.sub.navigation || false
@@ -110,6 +110,9 @@ export default {
       }
 
       return this.navigation.filter(n => !n.gender || n.gender === this.currentGender)
+    },
+    tiles () {
+      return this.sub.tiles || false
     },
     teaser () {
       return this.sub.teaser || false
@@ -124,9 +127,6 @@ export default {
     },
     logos () {
       return this.sub.logos || false
-    },
-    tiles () {
-      return this.sub.tiles || false
     },
     logoLineProps () {
       if (Array.isArray(this.logos)) {


### PR DESCRIPTION
Custom Tiles with fallback to MainNavigation. Add Json like in `block-navigation-main`with the `tiles` Identifier.

```
tiles:
  - children:
    - width: full
      children:
      - name: Neu
        route: "/home.html?sort=online%3Adesc"
        icon: new_releases
        backgroundColor: primary
      - name: Sale
        route: "/home.html?is_in_sale=true"
        icon: local_offer
        backgroundColor: sale
  - children:
    - width: full
      children:
      - name: Top Sellers
        route: "/home.html?sort=ranking_shop_bestseller%3Adesc"
        icon: flag
        backgroundColor: base-dark
      - name: Preorder
        route: "/clothing.html?preorder_searchable=6373"
        icon: date_range
        backgroundColor: base-dark
```
## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-226629

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
