### PR TITLE
#231143 - Add padding for iOS Toolbar (bottom) to Navigation

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Navigation/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Navigation/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <sidebar class="t-min-h-screen">
+  <sidebar class="t-min-h-screen t-pb-24">
     <template v-slot:top>
       <top-button icon="person" :text="loginButtonText" :tab-index="2" class="t-text-base-light" @click.native="login" />
     </template>

--- a/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Navigation/SubNavigation.vue
@@ -20,7 +20,7 @@
     </div>
     <div
       v-if="logos"
-      class="t-flex t-flex-wrap"
+      class="t-flex t-flex-wrap t-pb-24"
       @click="closeMenu"
     >
       <logo-line


### PR DESCRIPTION
iOS Toolbar hides the bottom Content. Add a Padding.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-231143

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
