### PR TITLE
#222888 - GTM - fix ImageURL

### DIFF
--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -66,7 +66,7 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
               case 'category':
                 product[attributeName] = value.map(v => pick(v, ['name', 'category_id']))
                 break
-              case 'image':
+              case 'catalogImage':
                 product[attributeName] = getThumbnailPath(value)
                 break
               default:

--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -5,6 +5,7 @@ import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 import GoogleTagManagerState, { AttributeMapItem } from '../types/GoogleTagManagerState'
 import { googleTagManager } from 'config'
+import { getThumbnailPath } from '@vue-storefront/core/helpers'
 
 import pick from 'lodash-es/pick'
 import isEmpty from 'lodash-es/isEmpty'
@@ -64,6 +65,9 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
                 break
               case 'category':
                 product[attributeName] = value.map(v => pick(v, ['name', 'category_id']))
+                break
+              case 'image':
+                product[attributeName] = getThumbnailPath(value)
                 break
               default:
                 product[attributeName] = value


### PR DESCRIPTION
The image URL in Datalayer was only `/t/e/test.jpg`. Added a case for CatalogImages with `getThumbnailPath()`

URL is now `https://www.impericon.com/medai/catalog/product/t/e/test.jpg`

Because all structured-data is based on Datalayer were all wrong and generates tons of error in the search-console.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-222888

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
