### PR TITLE
#234767 Consolidate calendar component

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/ICMAA/Cms/Pages/Calendar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/ICMAA/Cms/Pages/Calendar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="easter-calendar t-container">
+  <div class="t-container" :class="identifier">
     <div class="lg:t-p-4">
       <div class="wrapper t-p-4">
         <div class="t-grid t-grid-cols-2 sm:t-grid-cols-4 t-gap-4">
@@ -113,7 +113,7 @@ import { mapGetters } from 'vuex'
 import { toDayjsDate, getCurrentStoreviewDayjsDatetime } from 'icmaa-config/helpers/datetime'
 
 export default {
-  name: 'EasterCalendar',
+  name: 'Calendar',
   mixins: [ Page ],
   components: {
     PictureComponent
@@ -210,10 +210,12 @@ export default {
 
 <style lang="scss">
 
-$alt-easter-color: #52766F;
-
 .easter-calendar .wrapper {
-  background-color: $alt-easter-color;
+  background-color: #52766F;
+}
+
+.summer-calendar .wrapper {
+  background-color: #79C9CF;
 }
 
 </style>

--- a/src/themes/icmaa-imp/router/icmaa-cms/router.ts
+++ b/src/themes/icmaa-imp/router/icmaa-cms/router.ts
@@ -10,7 +10,6 @@ const TicketsComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-c
 const FestivalComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-festival" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/Festival.vue')
 const INSDComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-impericon-never-say-die" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/ImpericonNeverSayDie.vue')
 const DigitalEventsComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-digital-events" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/DigitalEvents.vue')
-const XmasCalendar = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-xmas-calendar" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/XmasCalendar.vue')
 const Calendar = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-calendar" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/Calendar.vue')
 const NextGeneration = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-next-generation" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/NextGeneration.vue')
 const NextGenerationVoting = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-next-generation-voting" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/NextGenerationVoting.vue')
@@ -28,7 +27,7 @@ export const routes: any = [
   { name: 'festival', path: '/:identifier', component: FestivalComponent },
   { name: 'impericon-never-say-die', path: '/:identifier', component: INSDComponent },
   { name: 'digital-events', path: '/:identifier', component: DigitalEventsComponent },
-  { name: 'xmas-calendar', path: '/:identifier', component: XmasCalendar },
+  { name: 'xmas-calendar', path: '/:identifier', component: Calendar },
   { name: 'calendar', path: '/:identifier', component: Calendar },
   { name: 'next-generation', path: '/:identifier', component: NextGeneration },
   { name: 'next-generation-voting', path: '/:identifier', component: NextGenerationVoting }

--- a/src/themes/icmaa-imp/router/icmaa-cms/router.ts
+++ b/src/themes/icmaa-imp/router/icmaa-cms/router.ts
@@ -11,7 +11,7 @@ const FestivalComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-
 const INSDComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-impericon-never-say-die" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/ImpericonNeverSayDie.vue')
 const DigitalEventsComponent = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-digital-events" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/DigitalEvents.vue')
 const XmasCalendar = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-xmas-calendar" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/XmasCalendar.vue')
-const EasterCalendar = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-easter-calendar" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/EasterCalendar.vue')
+const Calendar = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-calendar" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/Calendar.vue')
 const NextGeneration = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-next-generation" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/NextGeneration.vue')
 const NextGenerationVoting = () => import(/* webpackChunkName: "vsf-icmaa-cms-page-custom-next-generation-voting" */ 'theme/components/core/blocks/ICMAA/Cms/Pages/NextGenerationVoting.vue')
 
@@ -29,7 +29,7 @@ export const routes: any = [
   { name: 'impericon-never-say-die', path: '/:identifier', component: INSDComponent },
   { name: 'digital-events', path: '/:identifier', component: DigitalEventsComponent },
   { name: 'xmas-calendar', path: '/:identifier', component: XmasCalendar },
-  { name: 'easter-calendar', path: '/:identifier', component: EasterCalendar },
+  { name: 'calendar', path: '/:identifier', component: Calendar },
   { name: 'next-generation', path: '/:identifier', component: NextGeneration },
   { name: 'next-generation-voting', path: '/:identifier', component: NextGenerationVoting }
 ]


### PR DESCRIPTION
- Add identifier for CSS class
- default without background-color
- changed routes for easter- und summer-calendar in Storyblok

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-234767

## Checklist

- [ ] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
