### PR TITLE
Change URL path of new checkout to prevent LB conflicts

### DIFF
--- a/core/modules/cart/helpers/notifications.ts
+++ b/core/modules/cart/helpers/notifications.ts
@@ -5,7 +5,7 @@ import config from 'config';
 
 const proceedToCheckoutAction = () => ({
   label: i18n.t('Proceed to checkout'),
-  action: () => router.push(localizedRoute('/checkout', currentStoreView().storeCode))
+  action: () => router.push(localizedRoute({ name: 'checkout' }, currentStoreView().storeCode))
 });
 const checkoutAction = () => !config.externalCheckout ? proceedToCheckoutAction() : null;
 

--- a/src/modules/icmaa-checkout/routes.ts
+++ b/src/modules/icmaa-checkout/routes.ts
@@ -9,7 +9,7 @@ const CheckoutGatewaySuccess = () => import(/* webpackChunkName: "vsf-checkout-g
  * the ìcmaa-checkout` module as it was registered afterwards. So, keep that in mind.
  */
 export default [
-  { name: 'checkout', path: '/checkout', component: CheckoutPage, meta: { layout: 'empty', gtm: 'checkout' } },
+  { name: 'checkout', path: '/checkout-v2', component: CheckoutPage, meta: { layout: 'empty', gtm: 'checkout' } },
   { name: 'checkout-success', path: '/(checkout|order)-success', component: SuccessPage },
   { name: 'checkout-gateway-success', path: '/checkout-gateway-success', component: CheckoutGatewaySuccess, meta: { layout: 'empty' } }
 ]

--- a/src/modules/instant-checkout/components/InstantCheckout.vue
+++ b/src/modules/instant-checkout/components/InstantCheckout.vue
@@ -145,7 +145,7 @@ export default {
               response.complete()
               this.$store.dispatch('checkout/setThankYouPage', true)
               this.$store.dispatch('ui/setSidebar', { key: 'microcart' })
-              this.$router.push(this.localizedRoute('/checkout'))
+              this.$router.push(this.localizedRoute({ name: 'checkout' }))
               // clear cart without sync, because after order cart will be already cleared on backend
               this.$store.dispatch('cart/clear', { sync: false }, { root: true })
             }

--- a/src/themes/icmaa-imp/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Microcart/Microcart.vue
@@ -67,7 +67,7 @@ export default {
     continueShopping (toCheckout = false) {
       this.$store.dispatch('ui/closeAll')
       if (toCheckout === true) {
-        this.$router.push(this.localizedRoute('/checkout'))
+        this.$router.push(this.localizedRoute({ name: 'checkout' }))
       }
     },
     clearCart () {

--- a/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
+++ b/src/themes/icmaa-imp/mixins/product/addtocartMixin.ts
@@ -63,7 +63,7 @@ export default {
     continueShopping (toCheckout = false) {
       this.$store.dispatch('ui/closeAll')
       if (toCheckout === true) {
-        this.$router.push(this.localizedRoute('/checkout'))
+        this.$router.push(this.localizedRoute({ name: 'checkout' }))
       }
     },
     goToCheckout () {


### PR DESCRIPTION
We should change this back once the checkout is fully migrated. But for now this will cause a conflict inside the first LB.

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
