### PR TITLE
Hotfix // Improvements for `icmaa-checkout`

### DIFF
--- a/src/modules/icmaa-checkout-com/components/methods/apm/Ideal.vue
+++ b/src/modules/icmaa-checkout-com/components/methods/apm/Ideal.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
-    <base-input
+    <base-select
       type="text"
       id="bic"
       name="bic"
       v-model="additionalData.bic"
-      :placeholder="$t('BIC')"
+      :initial-option-text="$t('BIC')"
+      :options="issuer"
       :validations="[
         {
           condition: $v.additionalData.bic.$error && !$v.additionalData.bic.required,
@@ -24,19 +25,36 @@
 import { required } from 'vuelidate/lib/validators'
 import { bic } from 'icmaa-checkout-com/helpers/validators'
 import ApmMethod from 'icmaa-checkout-com/mixins/methods/ApmMethod'
-import BaseInput from 'theme/components/core/blocks/Form/BaseInput.vue'
+import BaseSelect from 'theme/components/core/blocks/Form/BaseSelect'
 
 export default {
   name: 'CheckoutComIdealInfo',
   mixins: [ ApmMethod ],
   components: {
-    BaseInput
+    BaseSelect
   },
   data () {
     return {
       additionalData: {
         bic: null
       }
+    }
+  },
+  computed: {
+    issuer () {
+      const options = []
+      const issuer = this.info?.issuer || []
+      issuer.forEach(country => {
+        const { name, issuers } = country
+        issuers.forEach(i => {
+          options.push({
+            label: `${i.name} (${name})`,
+            value: i.bic
+          })
+        })
+      })
+
+      return options
     }
   },
   validations: {

--- a/src/modules/icmaa-checkout/components/Shipping.ts
+++ b/src/modules/icmaa-checkout/components/Shipping.ts
@@ -80,6 +80,10 @@ export default {
           shippingMethod
         )
 
+        // Reset payment-method in case the shipping-/billing-address has changed.
+        // Otherwise "Payment-Method is not available" error-message might block the checkout step.
+        await this.$store.dispatch('checkout/savePaymentMethod', null)
+
         await this.$store.dispatch('cart/syncTotals', { forceServerSync: true })
         await this.$store.dispatch('cart/syncPaymentMethods', { forceServerSync: true })
 


### PR DESCRIPTION
* Add BIC select to iDeal payment-method
* Reset payment-method when saving shipping-method in checkout:
  This is a bugfix for when an address changes but a address-specific payment-method is already selected. E.g. you select iDeal in NL and change your address to DE and wont be able to finish your order because of  "Payment method is not available" response of `setTotals` action.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-233661

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
