### PR TITLE
#225750 Add new `hideSingleOptionsFilters` option for filter-navigation on CLP

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Category/Sidebar.vue
@@ -80,7 +80,7 @@ export default {
     }),
     availableFilters () {
       const submenuFilters = config.products.submenuFilters || []
-      const singleOptionFilters = config.products.singleOptionFilters || []
+      const hideSingleOptionsFilters = config.products.hideSingleOptionsFilters || []
       const attributes = this.attributes
 
       let filters = Object.entries(this.filters)
@@ -89,7 +89,17 @@ export default {
           const options = v[1].filter(o => o.id !== '0')
           return { attributeKey: v[0], options }
         })
-        .filter(f => (f.options.length > 1 || (f.options.length === 1 && singleOptionFilters.includes(f.attributeKey))) && !this.getSystemFilterNames.includes(f.attributeKey) && this.isVisibleFilter(f.attributeKey) && attributes[f.attributeKey])
+        .filter(f => {
+          return f.options.length > 0 &&
+            !this.getSystemFilterNames.includes(f.attributeKey) &&
+            this.isVisibleFilter(f.attributeKey) &&
+            attributes[f.attributeKey]
+        })
+        .filter(f => {
+          // Hide bands/brands if there is only one option (e.g. in band CLP)
+          const hideFilter = hideSingleOptionsFilters.includes(f.attributeKey)
+          return !hideFilter || (hideFilter && f.options.length > 1)
+        })
         .map(f => ({ ...f, submenu: submenuFilters.includes(f.attributeKey), attributeLabel: this.attributeLabel({ attributeKey: f.attributeKey }), position: attributes[f.attributeKey].position || 0 }))
         .map(this.sortOptions)
 


### PR DESCRIPTION
* This is a bugfix to prevent missing filters if only one option is available for the current collection, but also hide specififc attributes if needed – like bands and brands.

This change needs a new config value `hideSingleOptionsFilters`:
https://github.com/icmaa/shop-workspace/commit/1d3e44a6999c049c2f6a03439f0797dfd060ffd1

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-225750

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
