### PR TITLE
#239532 Improvements for SSR memory-leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "generate-files": "cross-env TS_NODE_PROJECT=\"tsconfig-build.json\" ts-node ./core/scripts/generate-files.ts",
     "start": "cross-env NODE_ENV=production node ./core/scripts/server.js",
     "start:pm2": "cross-env NODE_ENV=production pm2 start ecosystem.json $PM2_ARGS",
-    "start:inspect": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" node --inspect -r ts-node/register ./core/scripts/server",
+    "start:inspect": "cross-env NODE_ENV=production node --inspect ./core/scripts/server.js",
     "installer": "node ./core/scripts/installer",
     "installer:ci": "yarn installer --default-config",
     "all": "cross-env NODE_ENV=development node ./core/scripts/all",

--- a/src/themes/icmaa-imp/components/core/CookieNotification.vue
+++ b/src/themes/icmaa-imp/components/core/CookieNotification.vue
@@ -46,7 +46,7 @@ export default {
       this.loadCookieNotificationModal = false
     }
   },
-  async created () {
+  async beforeMount () {
     this.$store.dispatch(
       'ui/setModalPriority',
       { name: 'modal-cookie-notification', priority: 100 }

--- a/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -75,7 +75,7 @@ export default {
       component: null
     }
   },
-  created () {
+  beforeMount () {
     this.getComponent()
   },
   mounted () {

--- a/src/themes/icmaa-imp/components/core/blocks/MyAccount/MyProductAlerts.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/MyAccount/MyProductAlerts.vue
@@ -54,7 +54,7 @@ export default {
       return attributeCodes
     }
   },
-  async created () {
+  async beforeMount () {
     await this.$store.dispatch('icmaaProductAlert/fetchProductStockAlerts')
     await this.$store.dispatch('icmaaProductAlert/fetchParentProductsByStockIds', this.stockItems)
     await this.$store.dispatch('attribute/list', { filterValues: this.attributeCodes })

--- a/src/themes/icmaa-imp/layouts/Default.vue
+++ b/src/themes/icmaa-imp/layouts/Default.vue
@@ -31,10 +31,12 @@
         <div class="t-clearfix" />
       </main>
       <main-footer />
-      <auth-modal />
-      <notifications />
-      <cookie-notification />
-      <offline-badge />
+      <no-ssr>
+        <auth-modal />
+        <notifications />
+        <cookie-notification />
+        <offline-badge />
+      </no-ssr>
     </div>
     <vue-progress-bar />
   </div>

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -342,11 +342,13 @@ export default {
     catalogHooksExecutors.productPageVisited(this.product)
   },
   created () {
-    const selectVariantCallback = () => { this.userHasSelectedVariant = true }
-    this.$bus.$on('user-has-selected-product-variant', selectVariantCallback)
-    this.$once('hook:destroyed', () => {
-      this.$bus.$off('user-has-selected-product-variant', selectVariantCallback)
-    })
+    if (!isServer) {
+      const selectVariantCallback = () => { this.userHasSelectedVariant = true }
+      this.$bus.$on('user-has-selected-product-variant', selectVariantCallback)
+      this.$once('hook:beforeDestroy', () => {
+        this.$bus.$off('user-has-selected-product-variant', selectVariantCallback)
+      })
+    }
   }
 }
 </script>


### PR DESCRIPTION
* Bugfix for memory-leak on PDP 
  * `beforeDestroy` and `destroyed` events aren't called on SSR and therefore won't unbind the callback
* Update start:inspect command to run without `ts-node`
* Don't load dynamic content on `created` hook
  * This hooks would also be called on SSR and might cause unecessary memory and CPU usage

This PR should decrease the memory-usage under high load drastically.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-239532

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
