### PR TITLE
#243775 Bugfix for custom CLP sorting

### DIFF
--- a/src/modules/icmaa-catalog/helpers/defaultCategorySort.ts
+++ b/src/modules/icmaa-catalog/helpers/defaultCategorySort.ts
@@ -29,9 +29,9 @@ export const getCustomCategorySort = (category: Category): Record<string, string
  * @param {Category} category
  * @return {Record<string, string>|boolean}
  */
-export const getCategorySort = (category: Category): string => {
+export const getDefaultCategorySort = (category: Category): string => {
   const sort = getCustomCategorySort(category)
   return sort ? Object.values(sort)[0] : `${defaultCategorySort.attribute}:${defaultCategorySort.order}`
 }
 
-export default getCategorySort
+export default getDefaultCategorySort

--- a/src/modules/icmaa-catalog/store/category/actions/index.ts
+++ b/src/modules/icmaa-catalog/store/category/actions/index.ts
@@ -7,6 +7,7 @@ import { products, entities } from 'config'
 import { buildFilterProductsQuery } from '@vue-storefront/core/helpers'
 import { _prepareCategoryPathIds } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers'
 import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers'
+import getDefaultCategorySort from 'icmaa-catalog/helpers/defaultCategorySort'
 
 import omit from 'lodash-es/omit'
 import cloneDeep from 'lodash-es/cloneDeep'
@@ -47,7 +48,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     )
 
     const { includeFields, excludeFields } = getters.getIncludeExcludeFields(category)
-    const sort = searchQuery.sort || getters.getDefaultCategorySort
+    const sort = searchQuery.sort || getDefaultCategorySort(searchCategory)
     const separateSelectedVariant = getters.separateSelectedVariantInProductList
 
     const { items, perPage, start, total, aggregations, attributeMetadata } = await dispatch('product/findProducts', {


### PR DESCRIPTION
* Use `getDefaultCategorySort` in `loadCategoryProducts` action to prevent unready `route.params` state property on client-side requests

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-243775

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
