### PR TITLE
#245300 Bugfixes for add-to-cart /w incentives and on CLP

### DIFF
--- a/src/modules/icmaa-cart/index.ts
+++ b/src/modules/icmaa-cart/index.ts
@@ -11,4 +11,11 @@ export const IcmaaExtendedCartModule: StorefrontModule = function ({ store }) {
     store.dispatch('cart/updateFreeCartItems', data.serverItems)
     return data
   })
+
+  cartHooks.afterRemoveFromCart(async data => {
+    if (store.getters['cart/getFreeCartItems']?.length > 0) {
+      store.dispatch('cart/couponCallback')
+    }
+    return data
+  })
 }

--- a/src/modules/icmaa-cart/store/actions/couponActions.ts
+++ b/src/modules/icmaa-cart/store/actions/couponActions.ts
@@ -53,7 +53,7 @@ const actions: ActionTree<CartState, RootState> = {
    * There is already an up-to-date representation of the cart in `cart/shipping-information` request
    * of `syncTotals` but this isn't returned so we can't use it without extending the core excessivly.
    */
-  async couponCallback ({ getters, dispatch, commit }) {
+  async couponCallback ({ getters, dispatch }) {
     const { getCartItems, isTotalsSyncRequired } = getters
 
     const { result, resultCode } = await CartService.getItems()

--- a/src/themes/icmaa-imp/components/core/ProductTile.vue
+++ b/src/themes/icmaa-imp/components/core/ProductTile.vue
@@ -70,8 +70,19 @@ export default {
   methods: {
     async openAddToCartSidebar () {
       if (this.isSingleOptionProduct) {
+        const product = this.product
+        if (this.isOnesizeProduct) {
+          /**
+           * Bugfix: We need to replace the sku of cart-item by the SKU of the selected-variant
+           * to be able to check for it using `productsEquals` in `cart/mergeClientItem` action.
+           * Otherwise the product will be removed on reload or the next cart-action if you add
+           * an onesize product to cart from CLP.
+           */
+          Object.assign(product, { sku: product.selectedVariant.sku })
+        }
+
         this.$store.dispatch('ui/loader', { message: i18n.t('Please wait') })
-        this.addToCart(this.product)
+        this.addToCart(product)
           .then(() => { this.$store.dispatch('ui/loader', false) })
           .catch(() => { this.$store.dispatch('ui/loader', false) })
 


### PR DESCRIPTION
* #245300 Remove incentives if a single item is deleted from cart
* Bugfix for add-to-cart of onesize products in CLP
  * We need to replace the sku of cart-item by the SKU of the selected-variant to be able to check for it using `productsEquals` in `cart/mergeClientItem` action. Otherwise the product will be removed on reload or the next cart-action if you add an onesize product to cart from CLP.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-245300

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
