### PR TITLE
#242172 Bugfix for missing category--links on CLP

### DIFF
--- a/src/modules/icmaa-catalog/store/category/actions.ts
+++ b/src/modules/icmaa-catalog/store/category/actions.ts
@@ -52,8 +52,8 @@ const actions: ActionTree<CategoryState, RootState> = {
 
     return categories
   },
-  async loadChildCategoryFilter ({ dispatch, getters, commit }) {
-    let currentCategory: Category = getters.getCurrentCategory
+  async loadChildCategoryFilter ({ dispatch, getters, commit }, { category }: { category?: Category }) {
+    let currentCategory: Category = category || getters.getCurrentCategory
     if (currentCategory) {
       const { children_count, children_data: children } = currentCategory
       if (Number(children_count) === 0 || !children || children.length === 0) {

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -115,7 +115,7 @@ const composeInitialPageState = async (store, route, forceLoad = false, pageSize
 
     await Promise.all([
       store.dispatch('category-next/loadCategoryProducts', { route, category: currentCategory, pageSize }),
-      store.dispatch('category-next/loadChildCategoryFilter')
+      store.dispatch('category-next/loadChildCategoryFilter', { category: currentCategory })
     ])
 
     const breadCrumbsLoader = store.dispatch(


### PR DESCRIPTION
* The category-short-links on CLP might not be loaded on CSR because the new current category isn't yet set during `composeInitialPageState` method on CLP

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-242172

## Checklist

- [ ] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [ ] I'm aware of depending changes in other repositories
