### PR TITLE
#221258 Improve browser-back on CLP

### DIFF
--- a/src/modules/icmaa-url/store/getters.ts
+++ b/src/modules/icmaa-url/store/getters.ts
@@ -1,0 +1,13 @@
+import { GetterTree } from 'vuex'
+import { UrlState } from '@vue-storefront/core/modules/url/types/UrlState'
+import RootState from '@vue-storefront/core/types/RootState'
+import { LocalizedRoute } from '@vue-storefront/core/lib/types'
+
+export const getters: GetterTree<UrlState, RootState> = {
+  getCurrentRouteDispatcher: (state): boolean | LocalizedRoute => {
+    return state.dispatcherMap[state.currentRoute.fullPath] || false
+  },
+  getPrevRouteDispatcher: (state): boolean | LocalizedRoute => {
+    return state.dispatcherMap[state.prevRoute.fullPath] || false
+  }
+}

--- a/src/modules/icmaa-url/store/index.ts
+++ b/src/modules/icmaa-url/store/index.ts
@@ -1,7 +1,9 @@
 import { Module } from 'vuex'
 import { actions } from './actions'
+import { getters } from './getters'
 import { UrlState } from '@vue-storefront/core/modules/url/types/UrlState'
 
 export const ExtendedUrlStore: Module<UrlState, any> = {
-  actions
+  actions,
+  getters
 }

--- a/src/themes/icmaa-imp/pages/Category.vue
+++ b/src/themes/icmaa-imp/pages/Category.vue
@@ -118,7 +118,10 @@ const composeInitialPageState = async (store, route, forceLoad = false, pageSize
       // If browser-history-back event use cached products
       if (routerHelper.popStateDetected === true) {
         routerHelper.popStateDetected = false
-        return Promise.resolve()
+        const prevRoute = store.getters['url/getPrevRouteDispatcher']
+        if (prevRoute && prevRoute?.name !== 'category') {
+          return Promise.resolve()
+        }
       }
       return store.dispatch('category-next/loadCategoryProducts', { route, category: currentCategory, pageSize })
     }

--- a/src/themes/icmaa-imp/pages/SearchResult.vue
+++ b/src/themes/icmaa-imp/pages/SearchResult.vue
@@ -69,6 +69,7 @@ import { mapGetters, mapMutations } from 'vuex'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { IcmaaGoogleTagManagerExecutors } from 'icmaa-google-tag-manager/hooks'
 import * as productMutationTypes from '@vue-storefront/core/modules/catalog/store/product/mutation-types'
+import { routerHelper } from 'icmaa-catalog/helpers/popState'
 
 import AsyncSidebar from 'theme/components/core/blocks/AsyncSidebar/AsyncSidebar.vue'
 import FilterPresets from 'theme/components/core/blocks/Category/FilterPresets'
@@ -178,8 +179,13 @@ export default {
         const pageSize = route.params.pagesize || this.pageSize
         const category = { id: this.termHash, term: this.searchAlias }
 
-        await this.$store.dispatch('category-next/loadSearchProducts', { route, category, pageSize })
-        this.$store.dispatch('category-next/loadSearchBreadcrumbs')
+        // If browser-history-back event use cached products
+        if (routerHelper.popStateDetected === true) {
+          routerHelper.popStateDetected = false
+        } else {
+          await this.$store.dispatch('category-next/loadSearchProducts', { route, category, pageSize })
+          this.$store.dispatch('category-next/loadSearchBreadcrumbs')
+        }
 
         this.loading = false
       } catch (e) {


### PR DESCRIPTION
* Add check if prev-route was a category and add this feature to search-results page

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-221258

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
