### PR TITLE
#248473 Add new category-option for CLP filters

### DIFF
--- a/src/modules/icmaa-catalog/store/category/getters.ts
+++ b/src/modules/icmaa-catalog/store/category/getters.ts
@@ -45,7 +45,10 @@ const getters: GetterTree<CategoryState, RootState> = {
       }
     }
 
-    return intersection(parents, currentFilterKeys).length > 0
+    const category = getters.getCurrentCategory
+    const showFilterInCategoryFor = category?.ceShowFiltersFor || []
+
+    return intersection(parents, [...currentFilterKeys, ...showFilterInCategoryFor]).length > 0
   },
   getFilterCategories: (state, getters) => getters.getAvailableFilters.category || [],
   isCategoryInTicketWhitelist: () => (category: Category): boolean => {


### PR DESCRIPTION
* This is to show filters in specific categories that normally only would be visible if a parent filter is selected, like `pants_type` and `pants_size` in `jeans.html` category.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-248473

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
