### PR TITLE
#248913 Bugfixes for structured-data on PDP

### DIFF
--- a/src/modules/icmaa-google-tag-manager/components/jsonld/Product.vue
+++ b/src/modules/icmaa-google-tag-manager/components/jsonld/Product.vue
@@ -55,7 +55,7 @@ export default {
     rating () {
       const { count = 0, rating_summary: percent = 0 } = this.product.reviews
 
-      if (count === 0) return {}
+      if (parseInt(count) === 0) return {}
 
       return {
         'aggregateRating': {
@@ -87,7 +87,9 @@ export default {
           })
         })
 
-        return { offers }
+        if (offers.length > 0) {
+          return { offers }
+        }
       }
 
       return {


### PR DESCRIPTION
* Don't show `aggregateRating` if ratring-count is zero
* Show availability `out-of-stock` for configurable-products without child-products

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-248913

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
