### PR TITLE
Improve full-page-cache and cache-control

### DIFF
--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -258,6 +258,7 @@ app.use('*', async (req, res) => {
             }
           }
           res.setHeader('X-VS-Cache', 'Hit')
+          res.setHeader('Cache-Control', 'public, max-age=' + config.server.outputCacheDefaultTtl)
 
           if (output.body) {
             apiStatus(res, output.body, output.httpCode, false)

--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -80,7 +80,7 @@ app.use('/invalidate', async (req, res) => {
 
       const subPromises = []
       tags.forEach(tag => {
-        if (config.server.availableCacheTags.find(t => t === tag)) {
+        if (config.server.availableCacheTags.find(t => t === tag || tag.indexOf(t) === 0)) {
           subPromises.push(cache.invalidate(tag))
         } else {
           console.error(`Invalid tag name ${tag}`)

--- a/core/scripts/utils/cache-instance.js
+++ b/core/scripts/utils/cache-instance.js
@@ -8,7 +8,7 @@ if (config.server.useOutputCache) {
   const cacheVersionPath = path.resolve(path.join('core', 'build', 'cache-version.json'))
   let cacheKey = ''
   try {
-    cacheKey = JSON.parse(fs.readFileSync(cacheVersionPath) || '')
+    cacheKey = JSON.parse(fs.readFileSync(cacheVersionPath) || '') + ':'
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
* Add a `:` delimiter as suffix to FPC cache-prefix as desired in `ioredis` docs
* Add `cache-control` header for cached responses
* Add bugfix for invalidation by specific tags like `P-{ID}`

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
