### PR TITLE
Add complete CF cache-bust and improve catch of JSON errors

### DIFF
--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -61,6 +61,13 @@ export const apiStatus = async (res: ServerResponse, data, statusCode = 200, dro
     res.statusCode = statusCode
   }
 
+  if (typeof data === 'object') {
+    if (!res.getHeader('content-type')) {
+      res.setHeader('Content-Type', 'application/json')
+    }
+    return res.end(JSON.stringify(data))
+  }
+
   return res.end(data)
 }
 
@@ -100,7 +107,10 @@ app.use(async (req, res) => {
 
       return Promise.all(subPromises).then(async () => {
         serverHooksExecutors.afterCacheInvalidated({ tags, req: req as any })
-        return apiStatus(res, `Tags invalidated successfully [${query.tag}]`)
+        return apiStatus(res, {
+          message: `Tags invalidated successfully [${query.tag}]`,
+          status: 200
+        })
       }).catch(error => {
         console.error(error)
         return apiStatus(res, error, 500)
@@ -110,7 +120,10 @@ app.use(async (req, res) => {
       return apiStatus(res, 'Invalid parameters for Clear cache request', 500)
     }
   } else {
-    return apiStatus(res, 'Cache invalidation is not required, output cache is disabled')
+    return apiStatus(res, {
+      message: 'Cache invalidation is not required, output cache is disabled',
+      status: 200
+    })
   }
 }, { match: (url, req) => new RegExp(/^\/invalidate$/).test(url.split('?').shift()) })
 

--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -51,7 +51,7 @@ Object.entries(staticRoutes).forEach(([routePath, staticPath]) => {
   app.use(routePath, serveStaticMiddleware(staticPath))
 })
 
-const apiStatus = async (res: ServerResponse, data, statusCode = 200, dropExcp = true) => {
+export const apiStatus = async (res: ServerResponse, data, statusCode = 200, dropExcp = true) => {
   if (statusCode > 400) {
     if (dropExcp) {
       const statusMessage = typeof data === 'string' ? data : undefined
@@ -64,7 +64,8 @@ const apiStatus = async (res: ServerResponse, data, statusCode = 200, dropExcp =
   return res.end(data)
 }
 
-app.use('/invalidate', async (req, res) => {
+// Cache-invalidation route
+app.use(async (req, res) => {
   assertMethod(req, ['GET', 'POST'])
   if (config.server.useOutputCache) {
     const query = useQuery(req)
@@ -111,7 +112,7 @@ app.use('/invalidate', async (req, res) => {
   } else {
     return apiStatus(res, 'Cache invalidation is not required, output cache is disabled')
   }
-})
+}, { match: (url, req) => new RegExp(/^\/invalidate$/).test(url.split('?').shift()) })
 
 serverHooksExecutors.afterApplicationInitialized({ app, config: config.server, isProd })
 

--- a/src/modules/icmaa-cdn/server.h3.ts
+++ b/src/modules/icmaa-cdn/server.h3.ts
@@ -54,7 +54,7 @@ if (config.icmaa_cdn?.cloudflare?.enabled === true) {
   })
 
   serverHooks.afterApplicationInitialized(({ app }) => {
-    app.use('/invalidate/all', async (req, res) => {
+    app.use('/invalidate/cf/all', async (req, res) => {
       assertMethod(req, 'GET')
 
       if (config.server.useOutputCache) {

--- a/src/modules/icmaa-cdn/server.h3.ts
+++ b/src/modules/icmaa-cdn/server.h3.ts
@@ -1,22 +1,23 @@
 import config from 'config'
+import { assertMethod, useQuery } from 'h3'
+import { apiStatus } from '@vue-storefront/core/scripts/server.h3'
 import { serverHooks } from '@vue-storefront/core/server/hooks'
 import chunk from 'lodash/chunk'
 
 if (config.icmaa_cdn?.cloudflare?.enabled === true) {
+  const isProd = process.env.NODE_ENV === 'production'
   const defaults = { baseUrl: '', email: '', authKey: '', zone: '' }
   const { baseUrl, email, authKey, zone } = Object.assign({}, defaults, config.icmaa_cdn?.cloudflare)
-  const isProd = process.env.NODE_ENV === 'production'
+  const cfCacheBustUrl = `https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`
 
   serverHooks.addCacheInvalidatedSubPromise(({ promises, cache, tag, req }) => {
     const cacheKeyPromise = cache.redis.smembers('tags:' + tag)
       .then(pageKeys => {
-        const cacheBustRequests = []
-        const cfCacheBustUrl = `https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`
-
         const site = req.headers['x-vs-store-code'] as string || 'main'
         const currentKey = `page:${site}:`
         const paths = pageKeys.map(key => key.replace(currentKey, ''))
 
+        const cacheBustRequests = []
         const pathChunks = chunk(paths, 30) // CF has a 30-files-per-request limit
         pathChunks.forEach(chunk => {
         /** @see https://api.cloudflare.com/#zone-purge-files-by-url */
@@ -28,12 +29,16 @@ if (config.icmaa_cdn?.cloudflare?.enabled === true) {
               'Content-type': 'application/json; charset=UTF-8'
             },
             body: JSON.stringify({ files: chunk.map(p => baseUrl + p) })
-          }).then(res => res.json()).then(res => {
-            if (res.errors.length > 0) {
-              throw Error('An error during CloudFlare purge appeared: ' + JSON.stringify(res))
-            }
-            return res
-          })
+          }).then(res => res.json())
+            .catch(e => {
+              throw Error('An error during CloudFlare purge appeared. Can\'t render JSON response: ' + e.message)
+            })
+            .then(res => {
+              if (res.errors.length > 0) {
+                throw Error('An error during CloudFlare purge appeared: ' + JSON.stringify(res))
+              }
+              return res
+            })
 
           cacheBustRequests.push(batchCacheBust)
         })
@@ -46,5 +51,43 @@ if (config.icmaa_cdn?.cloudflare?.enabled === true) {
       .catch(err => console.error(err))
 
     promises.push(cacheKeyPromise)
+  })
+
+  serverHooks.afterApplicationInitialized(({ app }) => {
+    app.use('/invalidate/all', async (req, res) => {
+      assertMethod(req, 'GET')
+
+      if (config.server.useOutputCache) {
+        const query = useQuery(req)
+        if (!query.key || query.key !== config.server.invalidateCacheKey) { // clear cache pages for specific query tag
+          console.error('Invalid cache invalidation key')
+          return apiStatus(res, 'Invalid cache invalidation key', 500)
+        }
+      } else {
+        return apiStatus(res, 'Cache invalidation is not required, output cache is disabled')
+      }
+
+      return fetch(cfCacheBustUrl, {
+        method: 'POST',
+        headers: {
+          'X-Auth-Email': email,
+          'X-Auth-Key': authKey,
+          'Content-type': 'application/json; charset=UTF-8'
+        },
+        body: JSON.stringify({ purge_everything: true })
+      }).then(response => response.json())
+        .catch(e => {
+          throw Error('An error during CloudFlare purge appeared. Can\'t render JSON response: ' + e.message)
+        })
+        .then(response => {
+          if (response.errors.length > 0) {
+            throw Error('An error during CloudFlare purge appeared: ' + JSON.stringify(response))
+          }
+          return apiStatus(res, 'CloudFlare cache was purged successfully')
+        }).catch(error => {
+          console.error(error)
+          return apiStatus(res, error, 500)
+        })
+    })
   })
 }

--- a/src/modules/icmaa-cdn/server.h3.ts
+++ b/src/modules/icmaa-cdn/server.h3.ts
@@ -45,7 +45,7 @@ if (config.icmaa_cdn?.cloudflare?.enabled === true) {
 
         return Promise.all(cacheBustRequests)
           .then(() => {
-            if (!isProd) console.log('CloudFlare-Purge complete for:', pathChunks)
+            console.log('CloudFlare-Purge complete for:', pathChunks)
           })
       })
       .catch(err => console.error(err))


### PR DESCRIPTION
* Add endpoint `/invalidate/cf/all` to force complete cache-bust of CloudFlare CDN cache
* Improve implementation of `h3` invalidation route, to make it extendable using server-hooks
* Add improved logging to track cache-invalidation events in logs

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
