### PR TITLE
#249042 Add new link-list component to homepage and landing-pages

### DIFF
--- a/src/modules/icmaa-cms/components/Wrapper.vue
+++ b/src/modules/icmaa-cms/components/Wrapper.vue
@@ -30,6 +30,7 @@ const AsyncText = () => import(/* webpackChunkName: "vsf-content-block-text" */ 
 const AsyncPicture = () => import(/* webpackChunkName: "vsf-content-block-picture" */ 'theme/components/core/blocks/Picture')
 const AsyncProductlisting = () => import(/* webpackChunkName: "vsf-content-block-productlisting" */ '../../icmaa-category/components/ProductListingWidget')
 const AsyncCategorylist = () => import(/* webpackChunkName: "vsf-content-block-categorylist" */ 'icmaa-category/components/List/List')
+const AsyncLinkList = () => import(/* webpackChunkName: "vsf-content-block-linklist" */ 'theme/components/core/blocks/CategoryExtras/LinkList')
 
 export default {
   name: 'CmsBlockWrapper',
@@ -112,6 +113,15 @@ export default {
           },
           propsDefaults: {},
           cssClass: 't-mb-8',
+          padding: false
+        },
+        'component_linklist': {
+          component: AsyncLinkList,
+          propsTypes: {
+            items: 'json'
+          },
+          propsDefaults: {},
+          cssClass: 't-mb-4',
           padding: false
         }
       }

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LinkList.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LinkList.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="t-px-4 t--mx-4 t-flex t-flex-wrap">
+    <h4 v-if="!!title" class="t-w-full t-px-4 t-flex t-justify-between t-items-center t-text-xl t-text-base-dark t-mb-4">
+      {{ title }}
+      <span class="t-inline-block t-l t-text-primary t-text-xs t-leading-loose t-cursor-pointer" @click="openSidebarNavigation">
+        {{ $t('View all') }}
+      </span>
+    </h4>
+    <div
+      v-for="(item, i) in mappedItems"
+      :key="item.text + '-' + i"
+      class="t-flex t-w-1/2 lg:t-w-1/4 t-px-4 t-mb-4"
+    >
+      <router-link
+        :to="localizedRoute(item.link)"
+        class="t-px-4 t-py-3 t-w-full t-bg-white t-text-sm t-align-middle"
+      >
+        {{ item.text }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'LinkList',
+  props: {
+    title: {
+      type: [ Boolean, String ],
+      required: false,
+      default: false
+    },
+    items: {
+      type: [ Object, Array ],
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters({
+      gender: 'user/getGender'
+    }),
+    filteredItems () {
+      if (!this.items?.default) {
+        return this.items || []
+      }
+
+      if (!!this.gender && this.items[this.gender]) {
+        return this.items[this.gender]
+      } else {
+        return this.items.default || []
+      }
+    },
+    mappedItems () {
+      return this.filteredItems.map(i => ({ text: i[0], link: i[1] }))
+    }
+  },
+  methods: {
+    openSidebarNavigation () {
+      this.$store.dispatch('ui/setSidebar', { key: 'sidebar' })
+    }
+  }
+}
+</script>

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LinkList.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/LinkList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="t-px-4 t--mx-4 t-flex t-flex-wrap">
-    <h4 v-if="!!title" class="t-w-full t-px-4 t-flex t-justify-between t-items-center t-text-xl t-text-base-dark t-mb-4">
+    <h4 v-if="!!title && title !== ''" class="t-w-full t-px-4 t-flex t-justify-between t-items-center t-text-xl t-text-base-dark t-mb-4">
       {{ title }}
       <span class="t-inline-block t-l t-text-primary t-text-xs t-leading-loose t-cursor-pointer" @click="openSidebarNavigation">
         {{ $t('View all') }}

--- a/src/themes/icmaa-imp/pages/Home.vue
+++ b/src/themes/icmaa-imp/pages/Home.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="home" class="t-container">
     <teaser tags="2" :show-split="false" class="sm:t-pt-4 t-pb-8" />
+    <link-list :title="topCategories.title" :items="topCategories.items" class="t-pb-4" />
     <teaser tags="21" :show-large="false" :show-small-in-row="true" class="t-pb-8" />
     <teaser tags="2" :show-large="false" :limit="3" class="t-pb-8" />
     <teaser tags="20" :show-large="false" :show-small-in-row="true" class="t-pb-8" />
@@ -24,6 +25,7 @@
 import { mapGetters } from 'vuex'
 import Lazyload from 'icmaa-cms/components/Lazyload'
 import Teaser from 'theme/components/core/blocks/Teaser/Teaser'
+import LinkList from 'theme/components/core/blocks/CategoryExtras/LinkList'
 import LogoLine from 'theme/components/core/blocks/CategoryExtras/LogoLineBlock'
 import ProductListingWidget from 'icmaa-category/components/ProductListingWidget'
 import CmsBlock from 'icmaa-cms/components/Block'
@@ -32,14 +34,19 @@ export default {
   components: {
     Lazyload,
     Teaser,
+    LinkList,
     LogoLine,
     ProductListingWidget,
     CmsBlock
   },
   computed: {
     ...mapGetters({
-      isLoggedIn: 'user/isLoggedIn'
-    })
+      isLoggedIn: 'user/isLoggedIn',
+      getJsonBlockByIdentifier: 'icmaaCmsBlock/getJsonBlockByIdentifier'
+    }),
+    topCategories () {
+      return this.getJsonBlockByIdentifier('home-top-categories')
+    }
   },
   mounted () {
     if (!this.isLoggedIn && localStorage.getItem('redirect')) {
@@ -61,12 +68,14 @@ export default {
       this.$router.push(this.localizedHomeRoute)
     }
   },
-  async asyncData ({ context }) {
+  async asyncData ({ store, context }) {
     if (context) {
       context.output.cacheTags
         .add('home')
         .add('cms')
     }
+
+    await store.dispatch('icmaaCmsBlock/list', 'home-seo,home-top-categories')
   }
 }
 </script>


### PR DESCRIPTION
* We added a new component to the homepage for top-categories as test-links
* It's fetched from a Storyblok block called `home-top-categories` and its dependant on the selected gender
* This component is now also useable on landing-pages

## Screenshot

<img width="425" alt="Bildschirmfoto 2022-03-14 um 10 58 04" src="https://user-images.githubusercontent.com/6112764/158149212-1a5853f0-add7-4a21-a894-77584de16582.png">

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-249042

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories

