### PR TITLE
#250447 Bugfix for missing image on PDP

### DIFF
--- a/src/modules/icmaa-catalog/store/product/actions.ts
+++ b/src/modules/icmaa-catalog/store/product/actions.ts
@@ -20,8 +20,11 @@ const actions: ActionTree<ProductState, RootState> = {
    */
   setProductGallery ({ commit }, { product }) {
     let gallery = []
-    if (product.type_id === 'configurable' && product.hasOwnProperty('configurable_children')) {
-      if (!config.products.gallery.mergeConfigurableChildren && product.is_configured) {
+    if (product.type_id === 'configurable' &&
+      product.hasOwnProperty('configurable_children') &&
+      product.configurable_children?.length > 0
+    ) {
+      if (!config.products.gallery.mergeConfigurableChildren) {
         gallery = uniqBy(getMediaGallery(product), 'src')
       } else {
         gallery = uniqBy(configurableChildrenImages(product).concat(getMediaGallery(product)), 'src')


### PR DESCRIPTION
* If a product isn't configurable, due to missing children, the `setProductGallery` action isn't working and there also was an error inside the `if` clause for the `mergeConfigurableChildren` configuration in combination with unconfigured products.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-250447

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
