### PR TITLE
#250772 Remove cache-control due to problems

### DIFF
--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -206,11 +206,11 @@ app.use('*', async (req, res) => {
       }
 
       let tagsArray = []
-      if (config.server.useOutputCache &&
-          config.server.useOutputCacheTagging &&
+      if (config.server.useOutputCacheTagging &&
           context.output.cacheTags &&
           context.output.cacheTags.size > 0
       ) {
+        if (!config.server.useOutputCache) res.setHeader('X-VS-Cache', 'Disabled')
         tagsArray = Array.from(context.output.cacheTags)
         const cacheTags = tagsArray.join(' ')
         res.setHeader('X-VS-Cache-Tags', cacheTags)

--- a/core/scripts/server.h3.ts
+++ b/core/scripts/server.h3.ts
@@ -273,7 +273,6 @@ app.use('*', async (req, res) => {
             }
           }
           res.setHeader('X-VS-Cache', 'Hit')
-          res.setHeader('Cache-Control', 'public, max-age=' + config.server.outputCacheDefaultTtl)
 
           if (output.body) {
             apiStatus(res, output.body, output.httpCode, false)


### PR DESCRIPTION
* Remove cache-control due to problems with caching in the frontend between stores
* Make `X-VS-Cache-Tags` header souvereign of enabled output-cache

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-250772

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
