### PR TITLE
#251485 Add `404-*` cache-tag to 404 pages to be able to cache-bust by URL key

### DIFF
--- a/src/themes/icmaa-imp/pages/PageNotFound.vue
+++ b/src/themes/icmaa-imp/pages/PageNotFound.vue
@@ -34,6 +34,7 @@
 <script>
 import i18n from '@vue-storefront/i18n'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
 import { IcmaaGoogleTagManagerExecutors } from 'icmaa-google-tag-manager/hooks'
 import ButtonComponent from 'theme/components/core/blocks/Button'
 
@@ -47,10 +48,11 @@ export default {
       this.$store.dispatch('ui/setSidebar', { key: 'searchpanel' })
     }
   },
-  async asyncData ({ store, route, context }) {
+  async asyncData ({ route, context }) {
     Logger.log('Entering asyncData for PageNotFound ' + new Date())()
     if (context) {
-      context.output.cacheTags.add(`page-not-found`)
+      context.output.cacheTags.add('page-not-found')
+      context.output.cacheTags.add(`404-` + removeStoreCodeFromRoute(route?.path))
       context.server.response.statusCode = 404
     }
   },


### PR DESCRIPTION
## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-251485

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
