### PR TITLE
#252209 Use ´product.translatedName´ instead of `name` for translated product-titles

### DIFF
--- a/src/modules/icmaa-catalog/store/product/actions.ts
+++ b/src/modules/icmaa-catalog/store/product/actions.ts
@@ -53,7 +53,7 @@ const actions: ActionTree<ProductState, RootState> = {
     if (product && product.category_ids) {
       const routes = rootGetters['breadcrumbs/getBreadcrumbsRoutes']
       if (routes.length > 0 && rootGetters['breadcrumbs/isPreserved']) {
-        await dispatch('breadcrumbs/set', { current: product.name, routes, preserve: false }, { root: true })
+        await dispatch('breadcrumbs/set', { current: product.translatedName, routes, preserve: false }, { root: true })
         return
       }
 

--- a/src/modules/icmaa-google-tag-manager/components/jsonld/Product.vue
+++ b/src/modules/icmaa-google-tag-manager/components/jsonld/Product.vue
@@ -130,7 +130,7 @@ export default {
         '@context': 'https://schema.org/',
         '@type': 'Product',
         'sku': this.product.parentSku || this.product.sku,
-        'name': this.product.name.trim(),
+        'name': this.product.translatedName.trim(),
         'image': this.images,
         'description': this.description,
         ...this.brand,

--- a/src/themes/icmaa-imp/components/core/ProductTile.vue
+++ b/src/themes/icmaa-imp/components/core/ProductTile.vue
@@ -10,7 +10,7 @@
       </slot>
       <router-link :to="productLink" data-test-id="productLink" class="product-link t-block t-z-0">
         <promo-banner :product="product" class="t-absolute t-top-0 t-right-0" />
-        <product-image :image="thumbnail" :alt="product.name | htmlDecode" data-test-id="productImage" />
+        <product-image :image="thumbnail" :alt="product.translatedName | htmlDecode" data-test-id="productImage" />
       </router-link>
     </div>
     <router-link :to="productLink" tag="div" class="t-text-sm" v-if="!onlyImage">

--- a/src/themes/icmaa-imp/components/core/blocks/Checkout/AdditionalProducts/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Checkout/AdditionalProducts/Product.vue
@@ -9,7 +9,7 @@
       </div>
       <product-image
         :image="product.image"
-        :alt="product.name | htmlDecode"
+        :alt="product.translatedName | htmlDecode"
         data-test-id="productImage"
         class="t-block t-border t-border-base-lightest t-mb-2"
       />

--- a/src/themes/icmaa-imp/components/core/blocks/Checkout/Cart/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Checkout/Cart/Product.vue
@@ -1,7 +1,7 @@
 <template>
   <li class="t-flex t-py-2 t-border-b t-border-base-lightest">
     <div class="t-w-1/3 t-mr-4">
-      <product-image :image="thumbnail" :alt="product.name | htmlDecode" />
+      <product-image :image="thumbnail" :alt="product.translatedName | htmlDecode" />
     </div>
 
     <div class="t-w-2/3 t-flex t-flex-col t-py-2">

--- a/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Microcart/Product.vue
@@ -2,7 +2,7 @@
   <li class="t-flex t-py-2 t-border-b t-border-base-lightest" :class="{ 't-opacity-75': loading }" data-test-id="MicroCartProduct">
     <div class="t-w-1/3 t-mr-4">
       <router-link :to="productLink" @click.native="$store.dispatch('ui/setSidebar', { key: 'microcart', status: false })">
-        <product-image :image="thumbnail" :alt="product.name | htmlDecode" :key="product.sku" />
+        <product-image :image="thumbnail" :alt="product.translatedName | htmlDecode" :key="product.sku" />
       </router-link>
     </div>
 

--- a/src/themes/icmaa-imp/components/core/blocks/Product/ProductGallery.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Product/ProductGallery.vue
@@ -29,7 +29,7 @@
             v-for="(image, i) in images"
             :key="'zoom-' + product.sku + '-' + i"
             :image="image"
-            :alt="product.name | htmlDecode"
+            :alt="product.translatedName | htmlDecode"
             :sizes="sizes"
             :type="zoom ? 'fullsize' : 'gallery'"
             :enable-auto-reload="true"

--- a/src/themes/icmaa-imp/components/core/blocks/Wishlist/Product.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Wishlist/Product.vue
@@ -2,13 +2,13 @@
   <li class="t-w-full t-flex t-mr-4 t-py-2">
     <div class="t-w-1/3 t-mr-4">
       <router-link :to="productLink">
-        <product-image :image="thumbnail" :alt="product.name | htmlDecode" />
+        <product-image :image="thumbnail" :alt="product.translatedName | htmlDecode" />
       </router-link>
     </div>
     <div class="t-w-2/3 t-flex t-flex-col t-py-2 t-justify-between">
       <div class="t-mb-2">
         <router-link :to="productLink" class="t-block t-text-primary t-w-full t-text-sm t-leading-tight">
-          {{ product.name | htmlDecode }}
+          {{ product.translatedName | htmlDecode }}
         </router-link>
       </div>
       <div class="t-text-sm t-text-base-light t-pb-4 t-mb-2">

--- a/src/themes/icmaa-imp/components/core/blocks/Wishlist/WishlistButton.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Wishlist/WishlistButton.vue
@@ -99,7 +99,7 @@ export default {
       await this.$store.dispatch(`wishlist/${actionNameMap[action]}`, this.product)
       this.$store.dispatch('notification/spawnNotification', {
         type: 'success',
-        message: i18n.t(message, { productName: htmlDecode(this.product.name) }),
+        message: i18n.t(message, { productName: htmlDecode(this.product.translatedName) }),
         action1: { label: i18n.t('OK') }
       }, { root: true })
 


### PR DESCRIPTION
## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-252209

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
