### PR TITLE
#250854 Remove `vue.esm` and use `vue.runtime.esm` instead

### DIFF
--- a/src/modules/icmaa-cms/helpers/index.ts
+++ b/src/modules/icmaa-cms/helpers/index.ts
@@ -1,35 +1,56 @@
-import { defaultStoreCode } from 'config'
+import Vue from 'vue'
 import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export const getCurrentStoreCode = (): string => {
   return !currentStoreView() ? null : currentStoreView().storeCode
 }
 
-export const localizeRouterLink = (text: string): string => {
-  const regexLink = /(<a\shref=")(?!http|mailto)(.*?)(">)(.*?)(<\/a>)/gm
-  text = text.replace(regexLink, (match, g1, g2, g3, g4) =>
-    ['<router-link to="', g2, g3, g4, '</router-link>'].join(''))
-
-  const regexRouterLink = /(<router-link\sto=")(.*)(">.*<\/router-link>)/gm
-  return text.replace(regexRouterLink, (match, g1, g2, g3) =>
-    [g1, localizedRoute(g2, currentStoreView().storeCode), g3].join(''))
-}
-
 /**
- * @todo
- * This method to load a component by string requires the much bigger `vue.esm` bundle which includes the compiler
- * to render a component on runtime – we don't really need this as we mostly just return HTML including links,
- * but this links again contain links we want to treat as `<router-link>` to have client-side router navigation.
+ * This method searches for <a> tags inside an HTML string and replace them using <router-link>.
+ * We used the `vue.esm` bundle before to render links, this way we can do it without bloating the bundle.
+ * @see https://levelup.gitconnected.com/vue-js-replace-a-with-router-link-in-dynamic-html-c423beea0d17
+ * @see https://v2.vuejs.org/v2/guide/installation.html?redirect=true#Runtime-Compiler-vs-Runtime-only
  *
  * @param {string} text
  * @param {string} wrapper
  * @return {object}
  */
 export const stringToComponent = (text: string, wrapper: string = 'div'): object => {
-  if (!text || typeof text !== 'string') {
-    return {}
-  }
+  return {
+    render (createElement) {
+      // https://vuejs.org/v2/guide/render-function.html#createElement-Arguments
+      const options = {
+        domProps: { innerHTML: text }
+      }
+      return createElement(wrapper, options)
+    },
+    mounted () {
+      const anchors = this.$el.getElementsByTagName('a')
+      Array.from(anchors).forEach((anchor: Element) => {
+        const url = anchor.getAttribute('href')
 
-  text = localizeRouterLink(text)
-  return { template: `<${wrapper}>${text}</${wrapper}>` }
+        // Skip external links and mail to
+        if (/^(http|https|mailto:):\/\//.test(url)) return
+
+        // https://vuejs.org/v2/api/#propsData
+        const propsData = { to: localizedRoute(url) }
+        // https://vuejs.org/v2/api/#parent
+        // Without parent context RouterLink will be unable to access this.$router, etc.
+        const parent = this
+
+        const RouterLink = Vue.component('RouterLink')
+        const routerLink = new RouterLink({ propsData, parent })
+
+        // Mount and replaces anchor element
+        routerLink.$mount(anchor)
+
+        // Replace innerHtml
+        routerLink.$el.innerHTML = anchor.innerHTML
+
+        // Add original title if needed
+        const title = anchor.getAttribute('title')
+        if (title) routerLink.$el.setAttribute('title', title)
+      })
+    }
+  }
 }

--- a/src/themes/icmaa-imp/webpack.config.js
+++ b/src/themes/icmaa-imp/webpack.config.js
@@ -14,22 +14,6 @@ const SpritesmithPlugin = require('webpack-spritesmith')
 */
 module.exports = function (config, { isClient, isDev }) {
   /**
-   * Add Vue.js library with compiler to compile components in runtime
-   * @see https://vuejs.org/v2/guide/installation.html#Runtime-Compiler-vs-Runtime-only
-   */
-  if (isClient) {
-    const addCompiler = {
-      resolve: {
-        alias: {
-          'vue$': 'vue/dist/vue.esm.js'
-        }
-      }
-    }
-
-    config = merge(config, addCompiler)
-  }
-
-  /**
    * Inject postcss plugin for Tailwind.css to original webpack config.
    * Change the postcssConfig of the postcss-loader and add our loader plugin.
    *


### PR DESCRIPTION
* We don't need the whole Vue compiler in the client just to render some links into `<router-links>` inside HTML on client-side.
* I've refactored the `stringToComponent` method to replace the links inside of HTML based on the DOM and the `render` method of VueJS

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-250854

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
