### PR TITLE
#250854 Improve `prefetch`, `preload` and `precache` of application assets to save requests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -92,6 +92,9 @@
       "rel": "prefetch"
     }
   ],
+  "serviceWorker": {
+    "precacheFiles": [ ]
+  },
   "staticPages": {
     "updateOnRequest": true,
     "destPath": "static"

--- a/core/build/webpack.prod.sw.config.ts
+++ b/core/build/webpack.prod.sw.config.ts
@@ -6,7 +6,7 @@ export default {
       mode: 'production',
       swSrc: './core/service-worker/index.js',
       swDest: 'service-worker.js',
-      exclude: [ /\.html$/ ]
+      exclude: [ /\.html$/, /\.map$/ ]
     })
   ]
 }

--- a/core/modules/initial-resources/clientResourcesLoader.ts
+++ b/core/modules/initial-resources/clientResourcesLoader.ts
@@ -4,8 +4,9 @@ import config from 'config'
 const initialResources = addRegexpListToConfig(config)
 
 const prefetchRegexps = flatToRegexpList(
-  initialResources.filter(filterConfig => filterConfig.rel !== 'preload' && filterConfig.onload)
+  initialResources.filter(filterConfig => filterConfig.rel === 'prefetch' && filterConfig.onload)
 )
+
 const preloadRegexps = flatToRegexpList(
   initialResources.filter(filterConfig => filterConfig.rel === 'preload' && filterConfig.onload)
 )

--- a/core/modules/initial-resources/serverResourcesFilter.ts
+++ b/core/modules/initial-resources/serverResourcesFilter.ts
@@ -1,20 +1,26 @@
-import { addRegexpListToConfig, createRegexpMatcher, flatToRegexpList } from './helpers';
+import { addRegexpListToConfig, createRegexpMatcher, flatToRegexpList } from './helpers'
 
 const config = require('config')
 const initialResources = addRegexpListToConfig(config)
+const dissallowList = [ /\.map$/ ]
 
 const prefetchRegexps = flatToRegexpList(
-  initialResources.filter(filterConfig => filterConfig.rel !== 'preload')
+  initialResources.filter(filterConfig => filterConfig.rel === 'prefetch')
 )
+
 /**
  * vue-ssr method that filters prefetch files based on initialResources config
  */
 export const shouldPrefetch = (file: string) => {
+  const checkRegexpList = createRegexpMatcher(file)
+
+  const matchDissallowList = checkRegexpList(dissallowList)
+  if (matchDissallowList) return false
+
   if (prefetchRegexps.length) {
-    const checkRegexpList = createRegexpMatcher(file)
     const matchFilter = checkRegexpList(prefetchRegexps)
 
-    return !matchFilter
+    return matchFilter
   }
   return true
 }
@@ -22,15 +28,20 @@ export const shouldPrefetch = (file: string) => {
 const preloadRegexps = flatToRegexpList(
   initialResources.filter(filterConfig => filterConfig.rel === 'preload')
 )
+
 /**
  * vue-ssr method that filters preload files based on initialResources config
  */
 export const shouldPreload = (file: string) => {
+  const checkRegexpList = createRegexpMatcher(file)
+
+  const matchDissallowList = checkRegexpList(dissallowList)
+  if (matchDissallowList) return false
+
   if (preloadRegexps.length) {
-    const checkRegexpList = createRegexpMatcher(file)
     const matchFilter = checkRegexpList(preloadRegexps)
 
-    return !matchFilter
+    return matchFilter
   }
   return true
 }

--- a/core/service-worker/core-service-worker.js
+++ b/core/service-worker/core-service-worker.js
@@ -1,8 +1,17 @@
+import { serviceWorker as config } from 'config'
 import { precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
 import { NetworkFirst, CacheFirst } from 'workbox-strategies'
 
-precacheAndRoute(self.__WB_MANIFEST || [])
+let manifestFiles = self.__WB_MANIFEST || []
+
+const precacheAllowList = config?.precacheFiles || []
+if (precacheAllowList.length > 0) {
+  const allowRegExpList = precacheAllowList.map(string => new RegExp(string, 'gi'))
+  manifestFiles = manifestFiles.filter(file => allowRegExpList.some(r => r.test(file.url)))
+}
+
+precacheAndRoute(manifestFiles || [])
 
 const assetCache = new CacheFirst({
   cacheName: 'vsf-asset'

--- a/core/service-worker/core-service-worker.js
+++ b/core/service-worker/core-service-worker.js
@@ -9,6 +9,8 @@ const precacheAllowList = config?.precacheFiles || []
 if (precacheAllowList.length > 0) {
   const allowRegExpList = precacheAllowList.map(string => new RegExp(string, 'gi'))
   manifestFiles = manifestFiles.filter(file => allowRegExpList.some(r => r.test(file.url)))
+} else if (precacheAllowList.length === 1 && precacheAllowList[0] === 'none') {
+  manifestFiles = []
 }
 
 precacheAndRoute(manifestFiles || [])

--- a/src/themes/icmaa-imp/assets/flags/README.md
+++ b/src/themes/icmaa-imp/assets/flags/README.md
@@ -4,20 +4,19 @@ There is a component called `FlagIcon.vue` to include flags into out theme.
 
 We are using the library [flag-icon-css](https://github.com/lipis/flag-icon-css).  
 But to prevent overhead during the build we include only the flags we need as static assets.
+
 ## Component
 
 The component has two options:
 
 * **iso** - for the specific country
-* **format** - for the desrired format, options: `1x1` (Default), `4x3`
+* **format** - for the desired format, options: `1x1` (Default), `4x3`
 
 ## Sprites
 
-It's possible to use a SVG sprite map to save some requests on page load.
+We use a SVG sprite map to save some requests on page load.
 
 Because it seemed pretty complicated to implement [`svg-sprite-loader`](https://github.com/kisenka/svg-sprite-loader) into our webpack config, I decided to just use [`svg-sprite`](https://github.com/jkphl/svg-sprite) with a custom script to generate our language sprites.
-
-To enable sprites you need to set the `config.icmaa.useCountryFlagSprites` value in your configs to `true`. By default it is using the single file SVG language icons.
 
 ### Build sprites
 
@@ -29,4 +28,3 @@ node sprite-generator.js
 ```
 
 **THIS SHOULD BE AUTOMATED VIA WEBPACK SOME DAY WHEN I FIGURE OUT HOW WEBPACK WORKS WITH THIS IN DETAIL**
-

--- a/src/themes/icmaa-imp/components/core/blocks/FlagIcon.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/FlagIcon.vue
@@ -1,12 +1,15 @@
 <template>
-  <svg v-if="useSprite">
+  <svg>
     <use :xlink:href="`${sprite}#${isoFileCode}`" />
   </svg>
-  <img :src="image" :alt="iso" v-else>
 </template>
 
 <script>
-import config from 'config'
+
+const flagSprites = {
+  '1x1': require(`theme/assets/flags/1x1.svg`),
+  '4x3': require(`theme/assets/flags/4x3.svg`)
+}
 
 export default {
   props: {
@@ -23,20 +26,14 @@ export default {
     }
   },
   computed: {
-    useSprite () {
-      return config.icmaa.useCountryFlagSprites || false
-    },
     attributes () {
       return this.$attrs
     },
     sprite () {
-      return require(`theme/assets/flags/${this.format}.svg`)
+      return flagSprites[this.format]
     },
     isoFileCode () {
       return this.iso.toLowerCase()
-    },
-    image () {
-      return require(`theme/assets/flags/${this.format}/${this.isoFileCode}.svg`)
     }
   }
 }


### PR DESCRIPTION
* The workbox-precache was loading all application assets in idle-mode which leads to a lot unnecessary requests for the user and we don't really need this, as our application isn't available offline due to needed catalog- and cart-requests
* I filtered `.map` files from preload and prefetch links in the SSR respone `<head>`
* I also added a allow-list to the preload and prefetch config-filter for initial-ressources so we have better control of what is prefetched or -loaded
* The flag-component caused all flag SVGs to be loaded because of a variable in the component require statement  and those flags caused a lot unnecessary requests

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-250854

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
