### PR TITLE
#253999 Bugfix for missing products in product-links of bundled products

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/BundleSelector.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/AddToCartSidebar/BundleSelector.vue
@@ -76,7 +76,7 @@ export default {
             }
           } else {
             selectorOption = {
-              label: productLink.product.name,
+              label: productLink.name || productLink.product?.name || productLink.sku,
               optionId: option.option_id,
               productLink
             }


### PR DESCRIPTION
* If the child product of a bundle isn't visible and therefore not in the catalog, the `BundleSelector` component drops an error.
* I've updated the component to not fail for this edge-case and update the VSF indexer to pump the product-links name into the catalog

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-253999

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
