### PR TITLE
#253983 Debounce GTM search-event

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -217,7 +217,7 @@ export default {
 
           this.populateCategoryAggregations(aggregations)
 
-          IcmaaGoogleTagManagerExecutors.onSearchResult({ term: this.searchString, results: this.products })
+          this.gtmOnSearchResult()
         }).catch((err) => {
           Logger.error(err, 'components-search')()
         })
@@ -294,6 +294,15 @@ export default {
     },
     closeSidebar () {
       this.$store.dispatch('ui/setSidebar', { key: 'searchpanel', status: false })
+    },
+    gtmOnSearchResult () {
+      // Wait and check if the client is still typing to prevent a trigger of `onSearchResult` event
+      // and therefore data in GA we can't really relate to because of the sub-searches.
+      const currentString = this.searchString
+      setTimeout(() => {
+        if (currentString !== this.searchString) return
+        IcmaaGoogleTagManagerExecutors.onSearchResult({ term: this.searchString, results: this.products })
+      }, 2000)
     }
   },
   async mounted () {


### PR DESCRIPTION
* to limit results in GA by only final search requests and not the slow-typping sub-requests

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-253983

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
