### PR TITLE
Bugfix for reviews on PDP

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Reviews/ReviewsList.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Reviews/ReviewsList.vue
@@ -3,10 +3,10 @@
     <div v-if="!itemsPerPage || itemsPerPage.length === 0" class="t-bg-white t-rounded-sm t-p-4 t-text-sm t-text-base-light">
       {{ $t('No reviews have been posted yet. Please don\'t hesitate to share Your opinion and write the first review!') }}
     </div>
-    <div v-for="(item, index) in itemsPerPage" :key="index" itemprop="review" itemscope itemtype="http://schema.org/Review" class="t-bg-white t-rounded-sm t-p-4" :class="{ 't-mb-4': (index + 1) < perPage && (index + 1) < items.length }">
-      <meta itemprop="reviewAspect" :content="item.title" v-html="item.title">
-      <meta itemprop="itemReviewed" :content="productName | htmlDecode">
-      <meta itemprop="reviewBody" :content="item.detail | htmlDecode">
+    <div v-for="(item, index) in itemsPerPage" :key="index" itemscope itemtype="http://schema.org/Review" class="t-bg-white t-rounded-sm t-p-4" :class="{ 't-mb-4': (index + 1) < perPage && (index + 1) < items.length }">
+      <meta :content="item.title" v-html="item.title">
+      <meta :content="productName | htmlDecode">
+      <meta :content="item.detail | htmlDecode">
       <reviews-stars :rating="item.ratings_total" stars-size="sm" class="t-flex t-items-center t-text-md t-text-base-light t-mt-2" />
       <p class="t-text-sm t-my-4" v-html="item.detail" />
       <p class="t-text-sm t-text-base-light" v-text="item.nickname + ' / ' + item.date" />

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -94,7 +94,7 @@
         </div>
         <div class="reviews t-relative t-w-full t-p-8 t-bg-base-lighter lg:t-w-1/2" id="reviews">
           <lazyload data-test-id="ReviewsLoader">
-            <reviews :product="product" :product-name="product.translatedName" v-show="isOnline" />
+            <reviews :product="product" :product-name="product.translatedName" />
             <reviews-claim />
           </lazyload>
         </div>
@@ -134,7 +134,6 @@ import * as productMutationTypes from '@vue-storefront/core/modules/catalog/stor
 
 import { ReviewModule } from '@vue-storefront/core/modules/review'
 import { IcmaaExtendedReviewModule } from 'icmaa-review'
-import { RecentlyViewedModule } from '@vue-storefront/core/modules/recently-viewed'
 import Reviews from 'theme/components/core/blocks/Reviews/Reviews'
 
 import AsyncSidebar from 'theme/components/core/blocks/AsyncSidebar/AsyncSidebar'
@@ -197,7 +196,6 @@ export default {
   beforeCreate () {
     registerModule(ReviewModule)
     registerModule(IcmaaExtendedReviewModule)
-    registerModule(RecentlyViewedModule)
   },
   data () {
     return {


### PR DESCRIPTION
* Remove old `itemProps` from DOM
* Remove `RecentlyViewedModule` integration
* Don't hide reviews if offline

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
