### PR TITLE
#257310 Add header to newsletter subscription-page

### DIFF
--- a/src/modules/icmaa-newsletter/pages/Newsletter.vue
+++ b/src/modules/icmaa-newsletter/pages/Newsletter.vue
@@ -1,5 +1,11 @@
 <template>
   <div id="newsletter-page" :headline="content.headline">
+    <div v-if="content.header.img" class="t-container">
+      <div class="t--mx-4 md:t-mx-0 md:t-mt-4 lg:t-w-full t-flex t-flex-wrap t-px-4 t-mb-8">
+        <img :src="getMediaThumbnail(content.header.img, 0, 0)" :alt="content.header.alt" :title="content.header.alt">
+      </div>
+    </div>
+
     <div class="newsletter t-p-4 lg:t-p-8 lg:t-w-1/2 t-bg-white t-m-4 lg:t-my-8 lg:t-container lg:t-mx-auto" data-test-id="Newsletter">
       <h1 class="t-text-2xl t-text-primary t-leading-7">
         {{ $t("Get the Impericon Newsletter & and get yourself a {voucher_value} gift.", { voucher_value: newsletterVoucherValue }) }}

--- a/src/modules/icmaa-newsletter/pages/Newsletter.vue
+++ b/src/modules/icmaa-newsletter/pages/Newsletter.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="newsletter-page" :headline="content.headline">
-    <div v-if="content.header.img" class="t-container">
+    <div class="t-container">
       <div class="t--mx-4 md:t-mx-0 md:t-mt-4 lg:t-w-full t-flex t-flex-wrap t-px-4 t-mb-8">
-        <img :src="getMediaThumbnail(content.header.img, 0, 0)" :alt="content.header.alt" :title="content.header.alt">
+        <picture-component :alt="content.header.alt" :src="content.header.img" :width="780" :height="240" :placeholder="true" :sizes="sizes" ratio="13:4" class="t-flex-1 t-self-start" />
       </div>
     </div>
 
@@ -43,6 +43,7 @@ import Page from 'icmaa-cms/mixins/Page'
 import NewsletterMixin from 'theme/mixins/newsletterMixin'
 import SubscriptionStatus from '@vue-storefront/core/modules/newsletter/mixins/SubscriptionStatus'
 import MaterialIcon from 'theme/components/core/blocks/MaterialIcon'
+import PictureComponent from 'theme/components/core/blocks/Picture'
 
 const NewsletterPopup = () => import(/* webpackChunkName: "vsf-newsletter-modal" */ 'theme/components/core/NewsletterPopup.vue')
 
@@ -50,13 +51,26 @@ export default {
   name: 'Newsletter',
   components: {
     MaterialIcon,
-    NewsletterPopup
+    NewsletterPopup,
+    PictureComponent
   },
   mixins: [ Page, NewsletterMixin, SubscriptionStatus ],
   data () {
     return {
       loadNewsletterPopup: false,
       dataType: 'yaml'
+    }
+  },
+  computed: {
+    sizes () {
+      return [
+        // Order high-to-low is important
+        { media: '(min-width: 1280px)', width: 1248 },
+        { media: '(min-width: 1024px)', width: 992 },
+        { media: '(min-width: 640px)', width: 768 },
+        { media: '(min-width: 415px)', width: 640 },
+        { media: '(max-width: 415px)', width: 415 }
+      ]
     }
   },
   methods: {


### PR DESCRIPTION
content is maintained via Storyblok

```
header:
    img: impericon/newsletter/20220713_anmeldeseite_nl_header_en.jpg
    alt: Impericon Newsletter

whys .....
```

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-257310

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
