### PR TITLE
#258705 Add new RTE support for block-wrapper and add blocks to footer

### DIFF
--- a/src/modules/icmaa-cms/components/Wrapper.vue
+++ b/src/modules/icmaa-cms/components/Wrapper.vue
@@ -84,6 +84,13 @@ export default {
           cssClass: 't-mb-8',
           padding: false
         },
+        'component_rte': {
+          component: AsyncText,
+          propsTypes: {},
+          propsDefaults: {},
+          cssClass: 't-mb-8',
+          padding: false
+        },
         'component_image': {
           component: AsyncPicture,
           propsTypes: {

--- a/src/modules/icmaa-cms/components/Wrapper.vue
+++ b/src/modules/icmaa-cms/components/Wrapper.vue
@@ -53,7 +53,7 @@ export default {
             tags: (v) => v.join(',')
           },
           propsDefaults: {},
-          cssClass: 't-mb-8',
+          cssClass: 't-mb-4',
           padding: false
         },
         'component_logoline': {
@@ -74,22 +74,22 @@ export default {
           component: AsyncHeadline,
           propsTypes: {},
           propsDefaults: {},
-          cssClass: 't-my-4',
+          cssClass: 't-mb-4',
           padding: false
         },
         'component_text': {
           component: AsyncText,
           propsTypes: {},
           propsDefaults: {},
-          cssClass: 't-mb-8',
-          padding: false
+          cssClass: 't-mb-4',
+          padding: true
         },
         'component_rte': {
           component: AsyncText,
           propsTypes: {},
           propsDefaults: {},
-          cssClass: 't-mb-8',
-          padding: false
+          cssClass: 't-mb-4',
+          padding: true
         },
         'component_image': {
           component: AsyncPicture,
@@ -97,7 +97,7 @@ export default {
             sizes: 'json'
           },
           propsDefaults: {},
-          cssClass: 't-mb-8',
+          cssClass: 't-mb-4',
           padding: true
         },
         'component_productlisting': {
@@ -110,7 +110,7 @@ export default {
           propsDefaults: {
             filter: {}
           },
-          cssClass: 't-mb-8',
+          cssClass: 't-mb-4',
           padding: false
         },
         'component_categorylist': {
@@ -119,7 +119,7 @@ export default {
             categoryId: 'number'
           },
           propsDefaults: {},
-          cssClass: 't-mb-8',
+          cssClass: 't-mb-4',
           padding: false
         },
         'component_linklist': {

--- a/src/modules/icmaa-cms/helpers/index.ts
+++ b/src/modules/icmaa-cms/helpers/index.ts
@@ -4,8 +4,32 @@ import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multi
 // @ts-ignore:next-line
 const AsyncPictureComp = () => import(/* webpackChunkName: "vsf-content-block-picture" */ 'theme/components/core/blocks/Picture')
 
-export const getCurrentStoreCode = (): string => {
-  return !currentStoreView() ? null : currentStoreView().storeCode
+interface LinkOptions {
+  class: string
+}
+
+interface ImageOptions {
+  class: string,
+  sizes?: { media: string, width: number }[] | null,
+  width?: number,
+  height?: number,
+  [key: string]: any
+}
+
+const LinkDefaults: LinkOptions = {
+  class: 't-underline'
+}
+
+const ImageDefaults: ImageOptions = {
+  class: 't-block t-mb-4 lg:t-float-right lg:t-ml-4',
+  sizes: [
+    { media: '(min-width: 1280px)', width: 360 },
+    { media: '(min-width: 1024px)', width: 236 },
+    { media: '(min-width: 415px)', width: 364 },
+    { media: '(max-width: 414px)', width: 188 }
+  ],
+  width: 360,
+  height: 500
 }
 
 /**
@@ -18,7 +42,7 @@ export const getCurrentStoreCode = (): string => {
  * @param {string} wrapper
  * @return {object}
  */
-export const stringToComponent = (text: string, wrapper: string = 'div'): object => {
+export const stringToComponent = (text: string, wrapper: string = 'div', linkOptions: LinkOptions = LinkDefaults, imageOptions: ImageOptions = ImageDefaults): object => {
   return {
     render (createElement) {
       // https://vuejs.org/v2/guide/render-function.html#createElement-Arguments
@@ -37,7 +61,10 @@ export const stringToComponent = (text: string, wrapper: string = 'div'): object
           const url = anchor.getAttribute('href')
 
           // Skip external links and mail to
-          if (/^(http|https|mailto:):\/\//.test(url)) return
+          if (/^(http|https|mailto:):\/\//.test(url)) {
+            anchor.setAttribute('class', linkOptions.class)
+            return
+          }
 
           // https://vuejs.org/v2/api/#propsData
           const propsData = { to: localizedRoute(url) }
@@ -70,7 +97,8 @@ export const stringToComponent = (text: string, wrapper: string = 'div'): object
               const url = img.getAttribute('src')
 
               const parent = this
-              const propsData = { src: url }
+              const { sizes, width, height } = imageOptions
+              const propsData = { src: url, sizes, width, height }
 
               const alt = img.getAttribute('alt') || img.getAttribute('title')
               if (alt) Object.assign(propsData, { alt })
@@ -80,11 +108,15 @@ export const stringToComponent = (text: string, wrapper: string = 'div'): object
 
               picture.$mount(img)
 
-              picture.$el.setAttribute('class', 't-my-2')
+              picture.$el.setAttribute('class', imageOptions.class)
             })
           })
         }
       }
     }
   }
+}
+
+export const getCurrentStoreCode = (): string => {
+  return !currentStoreView() ? null : currentStoreView().storeCode
 }

--- a/src/modules/icmaa-cms/helpers/index.ts
+++ b/src/modules/icmaa-cms/helpers/index.ts
@@ -4,24 +4,38 @@ import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multi
 // @ts-ignore:next-line
 const AsyncPictureComp = () => import(/* webpackChunkName: "vsf-content-block-picture" */ 'theme/components/core/blocks/Picture')
 
-interface LinkOptions {
-  class: string
+interface CssClasses {
+  [key: string]: string,
+  a?: string,
+  img?: string,
+  p?: string,
+  blockquote?: string,
+  ul?: string,
+  ol?: string,
+  li?: string,
+  h1?: string,
+  h2?: string,
+  h3?: string,
+  h4?: string
+}
+
+const cssClassesDefaults: CssClasses = {
+  a: 't-underline',
+  img: 't-block lg:t-float-right lg:t-ml-4',
+  ol: 't-list-decimal t-ml-4',
+  ul: 't-list-disc t-ml-4',
+  blockquote: 't-border-l-4 t-border-base-lighter t-pl-4 t-py-2 t-italic',
+  h2: 't-anything'
 }
 
 interface ImageOptions {
-  class: string,
   sizes?: { media: string, width: number }[] | null,
   width?: number,
   height?: number,
   [key: string]: any
 }
 
-const LinkDefaults: LinkOptions = {
-  class: 't-underline'
-}
-
 const ImageDefaults: ImageOptions = {
-  class: 't-block t-mb-4 lg:t-float-right lg:t-ml-4',
   sizes: [
     { media: '(min-width: 1280px)', width: 360 },
     { media: '(min-width: 1024px)', width: 236 },
@@ -42,7 +56,7 @@ const ImageDefaults: ImageOptions = {
  * @param {string} wrapper
  * @return {object}
  */
-export const stringToComponent = (text: string, wrapper: string = 'div', linkOptions: LinkOptions = LinkDefaults, imageOptions: ImageOptions = ImageDefaults): object => {
+export const stringToComponent = (text: string, wrapper: string = 'div', cssClasses: CssClasses = cssClassesDefaults, imageOptions: ImageOptions = ImageDefaults): object => {
   return {
     render (createElement) {
       // https://vuejs.org/v2/guide/render-function.html#createElement-Arguments
@@ -52,6 +66,7 @@ export const stringToComponent = (text: string, wrapper: string = 'div', linkOpt
       return createElement(wrapper, options)
     },
     mounted () {
+      this.addDefaultCssClasses()
       this.parseAnchors(this.$el.getElementsByTagName('a'))
       this.parseImages(this.$el.getElementsByTagName('img'))
     },
@@ -62,7 +77,7 @@ export const stringToComponent = (text: string, wrapper: string = 'div', linkOpt
 
           // Skip external links and mail to
           if (/^(http|https|mailto:):\/\//.test(url)) {
-            anchor.setAttribute('class', linkOptions.class)
+            anchor.setAttribute('class', cssClasses.a)
             return
           }
 
@@ -81,8 +96,9 @@ export const stringToComponent = (text: string, wrapper: string = 'div', linkOpt
           // Replace innerHtml
           routerLink.$el.innerHTML = anchor.innerHTML
 
-          // Add default Tailwind class
-          routerLink.$el.setAttribute('class', 't-underline')
+          // Add original css classes
+          const cssClass = anchor.getAttribute('class')
+          if (cssClass) routerLink.$el.setAttribute('class', cssClass)
 
           // Add original title if needed
           const title = anchor.getAttribute('title')
@@ -108,9 +124,19 @@ export const stringToComponent = (text: string, wrapper: string = 'div', linkOpt
 
               picture.$mount(img)
 
-              picture.$el.setAttribute('class', imageOptions.class)
+              // Add original css classes
+              const cssClass = img.getAttribute('class')
+              if (cssClass) picture.$el.setAttribute('class', cssClass)
             })
           })
+        }
+      },
+      addDefaultCssClasses () {
+        for (let tag in cssClasses) {
+          Array.from(this.$el.getElementsByTagName(tag))
+            .forEach(($el: HTMLElement) => {
+              $el.setAttribute('class', cssClasses[tag])
+            })
         }
       }
     }

--- a/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Footer.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/CategoryExtras/Footer.vue
@@ -1,12 +1,11 @@
 <template>
-  <div class="t-flex t-flex-wrap t--mx-4 t-px-4" v-if="isVisible && (description || footerDescription)">
-    <div class="t-w-full t-mb-8 md:t-mb-0 t-px-4" v-if="description">
-      <h2 class="t-flex t-items-center t-h-10 t-text-1xl t-text-base-dark t-font-thin t-leading-1-em t-mb-4">
-        {{ categoryExtras.title }}
-      </h2>
-      <p class="t-text-base-tone t-text-sm t-leading-snug" v-html="description" />
+  <div class="category-footer" v-if="isVisible && (description || footerContent || footerDescription)">
+    <div class="t-mb-8 md:t-mb-0 t-px-4" v-if="description || footerContent">
+      <h2 class="t-any category-footer__headline" v-text="categoryExtras.title" v-if="categoryExtras.title" />
+      <p class="category-footer__description" v-html="description" v-if="description" />
+      <block-wrapper class="category-footer__description" :components="footerContent" v-if="footerContent" />
     </div>
-    <div class="t-w-full t-px-4 t-mt-8 t-text-xs t-text-base-lighter t-leading-snug" v-if="footerDescription">
+    <div class="t-mt-8 t-text-xs t-text-base-lighter t-leading-snug" v-if="footerDescription">
       {{ footerDescription }}
     </div>
   </div>
@@ -14,9 +13,13 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import BlockWrapper from 'icmaa-cms/components/Wrapper'
 
 export default {
   name: 'CategoryExtrasFooter',
+  components: {
+    BlockWrapper
+  },
   props: {
     foldDescription: {
       type: Boolean,
@@ -39,6 +42,9 @@ export default {
     description () {
       return this.categoryExtras.description
     },
+    footerContent () {
+      return this.categoryExtras.contentFooter
+    },
     footerDescription () {
       // This is the disclaimer text below the footer / weird attribute title
       return this.categoryExtras.descriptionFooter || false
@@ -46,3 +52,27 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.category-footer__headline {
+  @apply t-text-1xl t-text-base-dark t-font-thin t-leading-1-em t-mb-4;
+}
+
+.category-footer {
+
+  .category-footer__description {
+    @apply t-text-base-tone t-text-sm t-leading-snug;
+
+    h2 {
+      @apply category-footer__headline;
+    }
+
+    p, ul, ol, blockquote {
+      &:not(:last-child) {
+        @apply t-mb-4;
+      }
+    }
+  }
+}
+
+</style>

--- a/src/themes/icmaa-imp/components/core/blocks/RichText.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/RichText.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="t-my-8 t-container t-px-4">
-    <component :is="htmlContent" class="t-text-sm t-leading-relaxed t-text-base-tone" />
-  </div>
+  <component :is="htmlContent" class="t-text-sm t-leading-relaxed t-text-base-tone" />
 </template>
 
 <script>


### PR DESCRIPTION
* Added image support for block-wrapper and `stingToComponent` method
* Refactor `stingToComponent` to support custom styling per tag
* Improve styling of category-footer and add block-wrapper for new `ceContentFooter` field
* Improve styling in block-wrapper and add new `icmaa-rte`/`component_rte` component

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-258705

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
