### PR TITLE
#255405 Add custom link to the carrier logos

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Footer/Footer.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Footer/Footer.vue
@@ -34,11 +34,11 @@
               {{ $t("Payments & Shipping") }}
             </h2>
             <div class="logos lazyload t-flex t-justify-between t-flex-wrap t--mx-2" ref="serviceLogos">
-              <template v-for="(name, path) in carrierLogos">
-                <div :key="path" class="t-flex t-flex-initial t-w-1/3 t-justify-center t-px-2 t-pb-4">
+              <template v-for="(logo, index) in carrierLogos">
+                <div :key="index" class="t-flex t-flex-initial t-w-1/3 t-justify-center t-px-2 t-pb-4">
                   <div class="t-flex t-flex-initial t-h-12 t-w-full t-py-2 t-px-1 t-items-center t-justify-center t-border t-border-base-lighter t-rounded-sm">
-                    <router-link :to="localizedRoute(`/service-payment`)" :title="$t('Service')">
-                      <div :class="path" class="t-flex t-max-w-full" />
+                    <router-link :to="localizedRoute(logo.route)" :title="$t('Service')">
+                      <div :class="logo.path" class="t-flex t-max-w-full" />
                     </router-link>
                   </div>
                 </div>


### PR DESCRIPTION
… Releaseversion "footer-links" in Storyblok for all languages was created.

```
  "carrierLogos": [
    {
      "name": "PayPal",
      "path": "paypal",
      "route": "/service-payment"
    },
    {
      "name": "Klarna",
      "path": "klarna",
      "route": "/service-payment"
    },
    {
      "name": "DHL",
      "path": "dhl",
      "route": "/service-shipping"
    },
    {
      "name": "Visa",
      "path": "visa",
      "route": "/service-payment"
    },
    {
      "name": "MasterCard",
      "path": "mastercard",
      "route": "/service-payment"
    },
    {
      "name": "FedEx",
      "path": "fdx",
      "route": "/service-shipping"
    }
  ],
```

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-255405

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
