### PR TITLE
#261112 Bugfix for race-condition and infinite-loop in cart local-storage-sync

### DIFF
--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -1,20 +1,27 @@
 import rootStore from '@vue-storefront/core/store'
+import * as types from '@vue-storefront/core/modules/cart/store/mutation-types'
 import { storeViews } from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
-function checkMultistoreKey (key: string, path: string): boolean {
+function checkMultistoreKey (key: string, path: string, prefix: string = 'shop/cart/'): boolean {
   const { multistore, commonCache } = storeViews
   if (!multistore || (multistore && commonCache)) return key === path
-  return key === `${currentStoreView().storeCode}-${path}`
+  return key === `${currentStoreView().storeCode}-${prefix}${path}`
 }
 
-function getItemsFromStorage ({ key }) {
-  if (checkMultistoreKey(key, 'shop/cart/current-cart')) {
-    const value = JSON.parse(localStorage[key])
-    rootStore.dispatch('cart/updateCart', { items: value })
-  } else if (checkMultistoreKey(key, 'shop/cart/current-totals')) {
-    const value = JSON.parse(localStorage[key])
-    rootStore.dispatch('cart/updateTotals', value)
+function getItemsFromStorage ({ key, newValue }) {
+  if (checkMultistoreKey(key, 'current-cart')) {
+    const value = JSON.parse(newValue)
+    rootStore.commit(types.SN_CART + '/' + types.CART_LOAD_CART + types.LS_SUFFIX, value)
+  } else if (checkMultistoreKey(key, 'current-cart-token')) {
+    const value = JSON.parse(newValue)
+    rootStore.commit(types.SN_CART + '/' + types.CART_LOAD_CART_SERVER_TOKEN + types.LS_SUFFIX, value)
+  } else if (checkMultistoreKey(key, 'current-cart-hash')) {
+    const value = JSON.parse(newValue)
+    rootStore.commit(types.SN_CART + '/' + types.CART_SET_ITEMS_HASH + types.LS_SUFFIX, value)
+  } else if (checkMultistoreKey(key, 'current-totals')) {
+    const value = JSON.parse(newValue)
+    rootStore.commit(types.SN_CART + '/' + types.CART_UPD_TOTALS + types.LS_SUFFIX, value)
   }
 }
 

--- a/core/modules/cart/store/mutation-types.ts
+++ b/core/modules/cart/store/mutation-types.ts
@@ -1,4 +1,5 @@
 export const SN_CART = 'cart'
+export const LS_SUFFIX = '_LS'
 export const CART_ADD_ITEM = SN_CART + '/ADD'
 export const CART_DEL_ITEM = SN_CART + '/DEL'
 export const CART_DEL_NON_CONFIRMED_ITEM = SN_CART + '/DEL_NONCONFIRMED'

--- a/core/modules/cart/store/mutations.ts
+++ b/core/modules/cart/store/mutations.ts
@@ -93,4 +93,21 @@ const mutations: MutationTree<CartState> = {
   }
 }
 
+/**
+ * We can't use the following mutations for the localstorage-sync
+ * because they would create an infinite loop between the windows.
+ * Thats why we create a copy of this method with a suffix so the
+ * subscrided mutations won't get called.
+ */
+const localStorageMutations = [
+  types.CART_LOAD_CART,
+  types.CART_LOAD_CART_SERVER_TOKEN,
+  types.CART_SET_ITEMS_HASH,
+  types.CART_UPD_TOTALS
+]
+
+for (const name of localStorageMutations) {
+  mutations[name + types.LS_SUFFIX] = mutations[name]
+}
+
 export default mutations


### PR DESCRIPTION
* We can't use the cart-mutations for the localstorage-sync because they would create an infinite-loop between the windows. Thats why we create a copy of this method with a suffix so the subscrided mutations won't get called again.

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-261112

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
