### PR TITLE
Update `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "docker-compose.yml"
   ],
   "service": "app",
-  "workspaceFolder": "/var/www",
+  "workspaceFolder": "/workspace",
   "extensions": [
     "bradlc.vscode-tailwindcss",
     "christian-kohler.npm-intellisense",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
     "docker-compose.yml"
   ],
   "service": "app",
-  "workspaceFolder": "/var/www",
   "extensions": [
     "bradlc.vscode-tailwindcss",
     "christian-kohler.npm-intellisense",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
     "docker-compose.yml"
   ],
   "service": "app",
+  "workspaceFolder": "/var/www",
   "extensions": [
     "bradlc.vscode-tailwindcss",
     "christian-kohler.npm-intellisense",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,4 +4,3 @@ services:
     volumes:
       - .:/workspace:cached
     command: /bin/sh -c "while sleep 1000; do :; done"
- 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - './core:/var/www/core'
       - './src:/var/www/src'
       - './packages:/var/www/packages'
+      - './var:/var/www/var'
       - './babel.config.json:/var/www/babel.config.json'
       - './.eslintignore:/var/www/.eslintignore'
       - './.eslintrc.js:/var/www/.eslintrc.js'
@@ -20,7 +21,6 @@ services:
       - './tsconfig.json:/var/www/tsconfig.json'
       - './tsconfig-build.json:/var/www/tsconfig-build.json'
       - './shims.d.ts:/var/www/shims.d.ts'
-      - './var:/var/www/var'
     tmpfs:
       - /var/www/dist
     ports:


### PR DESCRIPTION
* Change `workspaceFolder` setting as we mount the root of our repo into the `/workspace` folder of the dev-container to have all files of the repo available in the service we are attaching to – otherwise folders like `./.git` or `.vscode` according to its Docker image will be missing and VSCode isn't working propertly.
* This setting seemed to be ignored by GitHub Codespaces before.

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
