### PR TITLE
Revert "#263774 Hide PayPal's checkout button until the bugfix (#874)"

### DIFF
--- a/src/themes/icmaa-imp/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/icmaa-imp/components/core/blocks/Checkout/PersonalDetails.vue
@@ -32,7 +32,7 @@
               {{ $t('Proceed as guest') }}
             </button-component>
           </div>
-          <!-- paypal-checkout-button color="white" class="t-flex-1 t-mt-2 t-z-0" / -->
+          <paypal-checkout-button color="white" class="t-flex-1 t-mt-2 t-z-0" />
         </div>
       </div>
       <div
@@ -213,7 +213,7 @@ import BaseCheckbox from 'theme/components/core/blocks/Form/BaseCheckbox'
 import BaseInput from 'theme/components/core/blocks/Form/BaseInput'
 import GenderSelect from 'theme/components/core/blocks/Form/GenderSelect'
 import ButtonComponent from 'theme/components/core/blocks/Button'
-// import PaypalCheckoutButton from 'icmaa-paypal/components/Checkout/ButtonWrapper'
+import PaypalCheckoutButton from 'icmaa-paypal/components/Checkout/ButtonWrapper'
 
 export default {
   name: 'PersonalDetails',
@@ -222,8 +222,8 @@ export default {
     ButtonComponent,
     BaseCheckbox,
     BaseInput,
-    GenderSelect
-    // PaypalCheckoutButton
+    GenderSelect,
+    PaypalCheckoutButton
   },
   mixins: [ PersonalDetails ]
 }


### PR DESCRIPTION
* This reverts commit e0a6170043abf48aeec561a3c7c264e83c6ed41e and is related to:  
  https://github.com/icmaa/magento/pull/1430
* We now can disable the PayPal button in the backend

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-263774

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
