### PR TITLE
#268886 Add Paqato tracking to customer-account and add custom `/order-tracking` route

### DIFF
--- a/core/i18n/resource/i18n/de-DE.csv
+++ b/core/i18n/resource/i18n/de-DE.csv
@@ -53,6 +53,7 @@
 "Reviews","Bewertungen"
 "Shopping cart is empty. Please add some products before entering Checkout","Ihr Warenkorb ist leer. Bitte fügen Sie mindestens ein Produkt hinzu bevor Sie zur Kasse gehen"
 "Some of the ordered products are not available!","Einige der bestellten Produkte sind nicht auf Lager!"
+"Sorry, but we couldn\'t find a valid tracking-code in this tracking URL.","Entschuldige, wir konnten leider keinen validen Tracking-Code in der aufgerufenen URL finden."
 "Sort By","Sortieren nach"
 "Stock check in progress, please wait while available stock quantities are checked","Bestandskontrolle läuft. Bitte warten Sie einen Moment bis die verfügbare Bestandsmenge geprüft worden ist"
 "Subtotal incl. tax","Zwischensumme inkl. MwSt."

--- a/core/i18n/resource/i18n/en-US.csv
+++ b/core/i18n/resource/i18n/en-US.csv
@@ -61,6 +61,7 @@
 "Select 1","Select 1"
 "Shopping cart is empty. Please add some products before entering Checkout","Shopping cart is empty. Please add some products before entering Checkout"
 "Some of the ordered products are not available!","Some of the ordered products are not available!"
+"Sorry, but we couldn\'t find a valid tracking-code in this tracking URL.","Sorry, but we couldn\'t find a valid tracking-code in this tracking URL."
 "Stock check in progress, please wait while available stock quantities are checked","Stock check in progress, please wait while available stock quantities are checked"
 "Subtotal incl. tax","Subtotal incl. tax"
 "Summary","Summary"

--- a/src/modules/icmaa-tracking/README.md
+++ b/src/modules/icmaa-tracking/README.md
@@ -11,7 +11,10 @@ Get order tracking information from API.
     // Endpoint of the api
     "endpoint": "/api/ext/icmaa-tracking",
     // The tracking-link is only shown for orders in this status
-    "orderStatusWhitelist": ["complete"]
+    "orderStatusWhitelist": ["complete"],
+    "paqato": {
+      "customerId": XXXXXX
+    }
   }
 }
 ```

--- a/src/modules/icmaa-tracking/components/TrackingLink.vue
+++ b/src/modules/icmaa-tracking/components/TrackingLink.vue
@@ -24,12 +24,21 @@ export default {
     }
   },
   computed: {
-    ...mapGetters({ getTracking: 'icmaaTracking/getTrackingByOrderId' }),
+    ...mapGetters({
+      getTracking: 'icmaaTracking/getTrackingByOrderId',
+      ordersHistory: 'user/getOrdersHistory',
+      store: 'icmaaConfig/getCurrentStore'
+    }),
     tracking () {
       return this.getTracking(this.orderId)
     },
     validStatus () {
       return config.icmaa_tracking.orderStatusWhitelist.includes(this.status)
+    },
+    order () {
+      return this.ordersHistory.find(order =>
+        parseInt(order.entity_id) === parseInt(this.orderId)
+      )
     }
   },
   methods: {
@@ -37,7 +46,23 @@ export default {
       this.$store.dispatch('ui/loader', { message: i18n.t('Please wait') })
       await this.$store.dispatch('icmaaTracking/fetchTracking', this.orderId)
       if (this.tracking) {
-        window.open(this.tracking.url, '_blank')
+        const languageCode = this.store.storeCode
+        const incrementId = this.order.increment_id + '-1'
+        const address = this.order?.extension_attributes?.shipping_assignments[0]?.shipping.address ||
+          this.order.billing_address
+        const postcode = address.postcode
+
+        this.$router.push({
+          name: 'order-tracking',
+          query: {
+            'tracking-code': [
+              languageCode,
+              this.tracking.id,
+              postcode,
+              incrementId
+            ].join('~')
+          }
+        })
       }
       this.$store.dispatch('ui/loader', false)
     }

--- a/src/modules/icmaa-tracking/index.ts
+++ b/src/modules/icmaa-tracking/index.ts
@@ -1,11 +1,14 @@
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
+import { setupMultistoreRoutes } from '@vue-storefront/core/lib/multistore'
 import { TrackingStore } from './store'
+import moduleRoutes from './routes'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 
-export const IcmaaTrackingModule: StorefrontModule = async function ({ store }) {
+export const IcmaaTrackingModule: StorefrontModule = async function ({ appConfig, router, store }) {
   store.registerModule('icmaaTracking', TrackingStore)
+  setupMultistoreRoutes(appConfig, router, moduleRoutes, 10)
 
-  EventBus.$on('user-after-logout', result => {
+  EventBus.$on('user-after-logout', () => {
     store.dispatch('icmaaTracking/clearTracking')
   })
 }

--- a/src/modules/icmaa-tracking/pages/Tracking.vue
+++ b/src/modules/icmaa-tracking/pages/Tracking.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="t-container">
+    <div class="t-py-8 t-px-4">
+      <div v-if="!checkTrackingParam">
+        {{ $t('Sorry, but we couldn\'t find a valid tracking-code in this tracking URL.') }}
+      </div>
+      <div
+        id="pqt-tracking"
+        :class="{ 't-bg-white t-p-4 md:t-p-8': sdKLoaded }"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import config from 'config'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'OrderTracking',
+  data () {
+    return {
+      sdKLoaded: false
+    }
+  },
+  computed: {
+    ...mapGetters({
+      store: 'icmaaConfig/getCurrentStore'
+    }),
+    trackingCode () {
+      return this.$route.query['tracking-code'] || false
+    },
+    checkTrackingParam () {
+      /**
+       * The original Paqato tracking-code has this format:
+       * https://tracking.paqato.com/[LANGUAGE-CODE]~[PAQATO-CUSTOMER-ID]~[TRACKING-ID]~[ZIP-CODE]~[ORDER-ID]
+       *
+       * The tracking-code for the GET param of the Paqato script misses the `PAQATO-CUSTOMER-ID`,
+       * because we set it on initial function call, so it results in:
+       * https://domain.com/de/order-tracking?tracking-code=[LANGUAGE-CODE]~~[TRACKING-ID]~[ZIP-CODE]~[ORDER-ID]
+       */
+      return !!this.customerId && !!this.trackingCode && this.trackingCode.split('~').length === 4
+    },
+    customerId () {
+      return config.icmaa_tracking?.paqato?.customerId || false
+    }
+  },
+  methods: {
+    loadSdkScript () {
+      return new Promise(resolve => {
+        const script = document.createElement('script')
+        script.async = true
+        script.src = '//tracking.paqato.com/scripts/pqt-tracking.min.js'
+        script.onload = () => { resolve() }
+        document.body.appendChild(script)
+      })
+    }
+  },
+  mounted () {
+    if (!this.trackingCode || !this.checkTrackingParam) {
+      this.$router.push(this.localizedHomeRoute)
+      this.$store.dispatch('notification/spawnNotification', {
+        type: 'error',
+        message: this.$t('Sorry, but we couldn\'t find a valid tracking-code in this tracking URL.'),
+        action1: { label: this.$t('OK') }
+      })
+    }
+
+    this.loadSdkScript().then(() => {
+      this.sdKLoaded = true
+
+      // eslint-disable-next-line
+      pqtTracking(this.customerId, this.store.storeCode)
+    })
+  }
+}
+</script>
+
+<style type="scss">
+.pqt-trail,
+.pqt-done {
+  @apply t-z-0;
+}
+</style>

--- a/src/modules/icmaa-tracking/routes.ts
+++ b/src/modules/icmaa-tracking/routes.ts
@@ -1,0 +1,5 @@
+const Tracking = () => import(/* webpackChunkName: "vsf-icmaa-order-tracking" */ 'icmaa-tracking/pages/Tracking.vue')
+
+export default [
+  { name: 'order-tracking', path: '/order-tracking', component: Tracking }
+]


### PR DESCRIPTION
Related to: https://github.com/icmaa/shop-workspace/commit/fc8dc1a25509b26d6dbe1cff40c0fee8afc3b939

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-268886

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
