### PR TITLE
#275506 Use the SKU/ID of the parent product in data-layer on PDP

### DIFF
--- a/src/modules/icmaa-google-tag-manager/store/index.ts
+++ b/src/modules/icmaa-google-tag-manager/store/index.ts
@@ -9,6 +9,7 @@ import { getThumbnailPath } from '@vue-storefront/core/helpers'
 
 import pick from 'lodash-es/pick'
 import isEmpty from 'lodash-es/isEmpty'
+import camelCase from 'lodash-es/camelCase'
 
 export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
   namespaced: true,
@@ -54,6 +55,11 @@ export const icmaaGoogleTagManagerModule: Module<GoogleTagManagerState, any> = {
           const value = item[attributeField] || product[attributeName]
           if (value) {
             switch (attributeType) {
+              case 'inherit':
+                product[attributeName] = item[camelCase(`parent-${attributeField}`)] ||
+                  product[camelCase(`parent-${attributeName}`)] ||
+                  value
+                break
               case 'price':
                 product[attributeName] = formatValue(value, 'en-US')
                 break

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -94,7 +94,7 @@
         </div>
         <div class="reviews t-relative t-w-full t-p-8 t-bg-base-lighter lg:t-w-1/2" id="reviews">
           <lazyload data-test-id="ReviewsLoader">
-            <reviews :product="product" :product-name="product.translatedName" v-if="product" />
+            <reviews :product="product" :product-name="product.translatedName" v-if="product && product.translatedName" />
             <reviews-claim />
           </lazyload>
         </div>

--- a/src/themes/icmaa-imp/pages/Product.vue
+++ b/src/themes/icmaa-imp/pages/Product.vue
@@ -94,7 +94,7 @@
         </div>
         <div class="reviews t-relative t-w-full t-p-8 t-bg-base-lighter lg:t-w-1/2" id="reviews">
           <lazyload data-test-id="ReviewsLoader">
-            <reviews :product="product" :product-name="product.translatedName" v-if="product && product.translatedName" />
+            <reviews :product="product" :product-name="product.translatedName || product.name" v-if="product" />
             <reviews-claim />
           </lazyload>
         </div>


### PR DESCRIPTION
* Connected to https://github.com/icmaa/shop-workspace/commit/d3769108b3b132f68faa75f9d8a5cd7846be4d65

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-275506

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
