### PR TITLE
#266752 Remove inherited category-id filter from `baseFilterProductsQuery`

### DIFF
--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -131,27 +131,8 @@ export function baseFilterProductsQuery (parentCategory, filters = []) { // TODO
     return searchProductQuery
   }
 
-  let childCats = [parentCategory.id]
-  if (parentCategory.children_data) {
-    let recurCatFinderBuilder = (category) => {
-      if (!category) {
-        return
-      }
+  searchProductQuery = searchProductQuery.applyFilter({ key: 'category_ids', value: parentCategory.id })
 
-      if (!category.children_data) {
-        return
-      }
-
-      for (let sc of category.children_data) {
-        if (sc && sc.id) {
-          childCats.push(sc.id)
-        }
-        recurCatFinderBuilder(sc)
-      }
-    }
-    recurCatFinderBuilder(parentCategory)
-  }
-  searchProductQuery = searchProductQuery.applyFilter({ key: 'category_ids', value: { 'in': childCats } })
   return searchProductQuery
 }
 

--- a/core/test/unit/helpers/buildFilterProductsQuery.spec.ts
+++ b/core/test/unit/helpers/buildFilterProductsQuery.spec.ts
@@ -64,7 +64,7 @@ describe('buildFilterProductsQuery method', () => {
     const result = buildFilterProductsQuery(currentCategory)
     const categoryFilter = result.getAppliedFilters().find(filter => filter.attribute === 'category_ids')
     expect(categoryFilter).toBeDefined()
-    expect(categoryFilter.value.in).toEqual([20, 21, 23, 24, 25, 26, 22, 27, 28])
+    expect(categoryFilter?.value).toEqual(20)
   });
 
   it('should build query with color filters', () => {
@@ -87,7 +87,7 @@ describe('buildFilterProductsQuery method', () => {
     const result = buildFilterProductsQuery(currentCategory, filters)
     const categoryFilter = result.getAppliedFilters().find(filter => filter.attribute === 'color')
     expect(categoryFilter).toBeDefined()
-    expect(categoryFilter.value.in).toEqual(['49', '50'])
+    expect(categoryFilter?.value.in).toEqual(['49', '50'])
   });
 
   it('should build query with single price from 0 filter', () => {
@@ -104,7 +104,7 @@ describe('buildFilterProductsQuery method', () => {
     const result = buildFilterProductsQuery(currentCategory, filters)
     const categoryFilter = result.getAppliedFilters().find(filter => filter.attribute === 'price')
     expect(categoryFilter).toBeDefined()
-    expect(categoryFilter.value.lte).toEqual(50)
+    expect(categoryFilter?.value.lte).toEqual(50)
   });
 
   it('should build query with single price between 50-100 filter', () => {
@@ -121,8 +121,8 @@ describe('buildFilterProductsQuery method', () => {
     const result = buildFilterProductsQuery(currentCategory, filters)
     const categoryFilter = result.getAppliedFilters().find(filter => filter.attribute === 'price')
     expect(categoryFilter).toBeDefined()
-    expect(categoryFilter.value.gte).toEqual(50)
-    expect(categoryFilter.value.lte).toEqual(100)
+    expect(categoryFilter?.value.gte).toEqual(50)
+    expect(categoryFilter?.value.lte).toEqual(100)
   });
 
   it('should build query with price filters', () => {
@@ -170,9 +170,9 @@ describe('buildFilterProductsQuery method', () => {
     const result = buildFilterProductsQuery(currentCategory, filters)
     const colorFilter = result.getAppliedFilters().find(filter => filter.attribute === 'color')
     expect(colorFilter).toBeDefined()
-    expect(colorFilter.value.in).toEqual(['49', '50'])
+    expect(colorFilter?.value.in).toEqual(['49', '50'])
     const erinFilter = result.getAppliedFilters().find(filter => filter.attribute === 'erin_recommends')
     expect(erinFilter).toBeDefined()
-    expect(erinFilter.value.in).toEqual(['1'])
+    expect(erinFilter?.value.in).toEqual(['1'])
   });
 });


### PR DESCRIPTION
* This is related to: https://github.com/icmaa/magento/pull/1490

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-266752

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
