### PR TITLE
#302646 Remove pagination param from canonical URL on CLP

### DIFF
--- a/src/modules/icmaa-meta/mixins/categoryMeta.ts
+++ b/src/modules/icmaa-meta/mixins/categoryMeta.ts
@@ -63,11 +63,15 @@ export default {
     }
 
     if (this.$route?.query?.p) {
-      link.push({
-        vmid: 'canonical',
-        rel: 'canonical',
-        href: config.icmaa_meta.base_url + this.$route.fullPath
-      })
+      /**
+       * #302646 We remove the pagination-param from canonical URL for an experiment
+       * @see https://www.icmaa.info/redmine/issues/302646
+       */
+      // link.push({
+      //   vmid: 'canonical',
+      //   rel: 'canonical',
+      //   href: config.icmaa_meta.base_url + this.$route.fullPath
+      // })
 
       const { page } = this.stats
       if (page > 1) {


### PR DESCRIPTION
## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-302646

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
